### PR TITLE
Further tweaks for the default configuration.

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -513,9 +513,11 @@ public class SurvivalFly extends Check {
         
         // Simple way to prevent players from sprinting if they have the blindness effect. 
         // Possibly just merge this with sprintback?
-        if (player.isSprinting() && player.hasPotionEffect(PotionEffectType.BLINDNESS)) {
-        	hDistanceAboveLimit = Math.max(hDistanceAboveLimit, hDistance);
-        	tags.add("badsprint");
+        if (sprinting && player.hasPotionEffect(PotionEffectType.BLINDNESS)
+	    && data.lostSprintCount == 0
+            && !pData.hasPermission(Permissions.MOVING_SURVIVALFLY_SPRINTING, player)) {
+            hDistanceAboveLimit = Math.max(hDistanceAboveLimit, hDistance);
+            tags.add("badsprint");
         }
         
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -25,6 +25,8 @@ import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.compat.BridgeMisc;
 import fr.neatmonster.nocheatplus.compat.BridgeMaterial;
 
+
+
 /**
  * These are the default settings for NoCheatPlus. They will be used in addition to/in replacement of configurations
  * given in the configFactory.yml file.
@@ -32,9 +34,6 @@ import fr.neatmonster.nocheatplus.compat.BridgeMaterial;
 public class DefaultConfig extends ConfigFile {
 
     // TODO: Other version details ?
-
-    private static final String unifiedBlockDirectionActions = "vl>1 cancel vl>15 cancel log:bdirection:4:8:i vl>200 cancel log:bdirection:1:5:if cmdc:kickillegalblockinteract:1:5";
-    private static final String unifiedBlockReachActions = "cancel log:breach:5:6:i";
 
     /**
      * Instantiates a new default configuration.
@@ -99,7 +98,8 @@ public class DefaultConfig extends ConfigFile {
                 "nocheatplus.checks.moving.survivalfly.* :: INTERVAL:10" // (Excludes the sf base permission.)
                 ), 1154);
 
-        // Protection features.
+
+        /* Protection features. */
         // Hide plugins.
         set(ConfPaths.PROTECT_PLUGINS_HIDE_ACTIVE, true, 785);
         set(ConfPaths.PROTECT_PLUGINS_HIDE_NOPERMISSION_MSG, "&cI'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.", 785);
@@ -114,89 +114,92 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.PROTECT_CLIENTS_MOTD_ACTIVE, true, 785);
         set(ConfPaths.PROTECT_CLIENTS_MOTD_ALLOWALL, false, 785);
 
+
         /* Checks! */
         set(ConfPaths.CHECKS_ACTIVE, true, 1144);
         set(ConfPaths.CHECKS_LAG, true, 1144);
         set(ConfPaths.CHECKS_DEBUG, false, 1144);
 
+
         /* BlockBreak */
         set(ConfPaths.BLOCKBREAK_ACTIVE, "default", 1144);
-
+        // Direction
         set(ConfPaths.BLOCKBREAK_DIRECTION_CHECK, "default", 785);
         set(ConfPaths.BLOCKBREAK_DIRECTION_ACTIONS, "cancel", 1154);
-
+        // FastBreak
         set(ConfPaths.BLOCKBREAK_FASTBREAK_CHECK, "default", 785);
         set(ConfPaths.BLOCKBREAK_FASTBREAK_STRICT, true, 785);
-        set(ConfPaths.BLOCKBREAK_FASTBREAK_DELAY, 95, 785); //100
+        set(ConfPaths.BLOCKBREAK_FASTBREAK_DELAY, 95, 785); 
         set(ConfPaths.BLOCKBREAK_FASTBREAK_MOD_SURVIVAL, 100, 785);
         set(ConfPaths.BLOCKBREAK_FASTBREAK_GRACE, 2000, 785);
         set(ConfPaths.BLOCKBREAK_FASTBREAK_ACTIONS, "cancel vl>5 cancel log:fastbreak:4:2:i vl>50 cancel log:fastbreak:0:2:if cmdc:kickfastbreak:2:5", 1154);
-
+        // Frequency
         set(ConfPaths.BLOCKBREAK_FREQUENCY_CHECK, "default", 785);
         set(ConfPaths.BLOCKBREAK_FREQUENCY_MOD_CREATIVE, 95, 785);
         set(ConfPaths.BLOCKBREAK_FREQUENCY_MOD_SURVIVAL, 45, 785);
         set(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_TICKS, 5, 785);
         set(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_LIMIT, 7, 785);
         set(ConfPaths.BLOCKBREAK_FREQUENCY_ACTIONS, "cancel vl>5 log:bbfrequency:3:5:i cancel vl>40 log:bbfrequency:0:5:if cancel cmdc:kickfrequency:0:5", 1154);
-
+        // NoSwing
         set(ConfPaths.BLOCKBREAK_NOSWING_CHECK, "default", 785);
         set(ConfPaths.BLOCKBREAK_NOSWING_ACTIONS, "cancel vl>10 log:noswing:0:5:i cancel", 785);
-
+        // Reach
         set(ConfPaths.BLOCKBREAK_REACH_CHECK, "default", 785);
         set(ConfPaths.BLOCKBREAK_REACH_ACTIONS, "cancel", 1154);
-
+        // WrongBlock
         set(ConfPaths.BLOCKBREAK_WRONGBLOCK_CHECK, "default", 785);
         set(ConfPaths.BLOCKBREAK_WRONGBLOCK_LEVEL, 20, 1154);
         set(ConfPaths.BLOCKBREAK_WRONGBLOCK_IMPROBABLE_FEEDONLY, false, 1154);
         set(ConfPaths.BLOCKBREAK_WRONGBLOCK_IMPROBABLE_WEIGHT, 2.0, 1154);
-        set(ConfPaths.BLOCKBREAK_WRONGBLOCK_ACTIONS, "cancel vl>10 log:bwrong:2:5:i cancel vl>30 log:bwrong:0:5:if cancel cmdc:kickwb:0:5", 1154);
+        set(ConfPaths.BLOCKBREAK_WRONGBLOCK_ACTIONS, "cancel vl>10 log:bwrong:2:5:i cancel vl>30 cancel log:bwrong:0:5:if cmdc:kickwb:0:5", 1154);
+
 
         /* BlockInteract */
         set(ConfPaths.BLOCKINTERACT_ACTIVE, "default", 1144);
-
+        // Direction
         set(ConfPaths.BLOCKINTERACT_DIRECTION_CHECK, "default", 785);
-        set(ConfPaths.BLOCKINTERACT_DIRECTION_ACTIONS, unifiedBlockDirectionActions, 785);
-
+        set(ConfPaths.BLOCKINTERACT_DIRECTION_ACTIONS, "vl>1 cancel vl>15 cancel log:bdirection:4:8:i vl>200 cancel log:bdirection:1:5:if cmdc:kickillegalblockinteract:1:5", 1154);
+        // Reach
         set(ConfPaths.BLOCKINTERACT_REACH_CHECK, "default", 785);
-        set(ConfPaths.BLOCKINTERACT_REACH_ACTIONS, unifiedBlockReachActions, 785);
-
+        set(ConfPaths.BLOCKINTERACT_REACH_ACTIONS, "cancel log:breach:5:6:i", 1154);
+        // Speed
         set(ConfPaths.BLOCKINTERACT_SPEED_CHECK, "default", 785);
         set(ConfPaths.BLOCKINTERACT_SPEED_INTERVAL, 2000, 785);
-        set(ConfPaths.BLOCKINTERACT_SPEED_LIMIT, 55, 1154); // Old limit: 60
+        set(ConfPaths.BLOCKINTERACT_SPEED_LIMIT, 55, 1154); 
         set(ConfPaths.BLOCKINTERACT_SPEED_ACTIONS, "cancel vl>10 cancel log:bspeed:5:4:i cancel vl>500 cancel log:bspeed:0:5:icf cmdc:kickbspeed:2:5", 1154);
-
+        // Visible
         set(ConfPaths.BLOCKINTERACT_VISIBLE_CHECK, "default", 785);
-        set(ConfPaths.BLOCKINTERACT_VISIBLE_ACTIONS, "cancel vl>30 log:bvisible:8:5:if cancel", 1154); // Visible + stone generators = fps NCP issue #575
+        set(ConfPaths.BLOCKINTERACT_VISIBLE_ACTIONS, "cancel vl>30 log:bvisible:8:5:if cancel", 1154); 
 
 
         /* BlockPlace */
         set(ConfPaths.BLOCKPLACE_ACTIVE, "default", 1144);
-
+        // Against
         set(ConfPaths.BLOCKPLACE_AGAINST_CHECK, "default", 785);
         set(ConfPaths.BLOCKPLACE_AGAINST_ACTIONS, "cancel log:against:1:5:i vl>10 cancel log:against:0:2:if cmdc:kickagainst:0:10", 1154);
-
+        // AutoSign
         set(ConfPaths.BLOCKPLACE_AUTOSIGN_CHECK, "default", 785);
         set(ConfPaths.BLOCKPLACE_AUTOSIGN_SKIPEMPTY, false, 785);
         set(ConfPaths.BLOCKPLACE_AUTOSIGN_ACTIONS, "cancel vl>10 log:bautosign:0:3:if cancel", 785);
-
+        // Direction
         set(ConfPaths.BLOCKPLACE_DIRECTION_CHECK, "default", 785);
         set(ConfPaths.BLOCKPLACE_DIRECTION_ACTIONS, "cancel", 1154);
-
+        // FastPlace
         set(ConfPaths.BLOCKPLACE_FASTPLACE_CHECK, "default", 785);
-        set(ConfPaths.BLOCKPLACE_FASTPLACE_LIMIT, 15, 1154); // Old limit: 22
+        set(ConfPaths.BLOCKPLACE_FASTPLACE_LIMIT, 15, 1154); 
         set(ConfPaths.BLOCKPLACE_FASTPLACE_SHORTTERM_TICKS, 10, 785);
         set(ConfPaths.BLOCKPLACE_FASTPLACE_SHORTTERM_LIMIT, 6, 785);
         set(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_FEEDONLY, false, 1154);
         set(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_WEIGHT, 0.5, 1154);
         set(ConfPaths.BLOCKPLACE_FASTPLACE_ACTIONS, "cancel vl>5 cancel log:fastplace:8:3:i vl>20 cancel log:fastplace:2:4:i vl>80 cancel log:fastplace:0:10:if cmdc:kickfastplace:1:10", 1154);
-
+        // Reach
         set(ConfPaths.BLOCKPLACE_REACH_CHECK, "default", 785);
         set(ConfPaths.BLOCKPLACE_REACH_ACTIONS, "cancel", 1154);
-
+        // NoSwing
         set(ConfPaths.BLOCKPLACE_NOSWING_CHECK, "default", 785);
         set(ConfPaths.BLOCKPLACE_NOSWING_EXCEPTIONS, Arrays.asList(BridgeMaterial.LILY_PAD.toString(), Material.FLINT_AND_STEEL.toString()), 1154);
         set(ConfPaths.BLOCKPLACE_NOSWING_ACTIONS, "cancel vl>10 log:noswing:2:5:i cancel", 1154);
-        
+        // Scaffold
         set(ConfPaths.BLOCKPLACE_SCAFFOLD_CHECK, "default", 1154);
         set(ConfPaths.BLOCKPLACE_SCAFFOLD_ANGLE, true, 1154);
         set(ConfPaths.BLOCKPLACE_SCAFFOLD_SPRINT, true, 1154);
@@ -205,33 +208,32 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.BLOCKPLACE_SCAFFOLD_PITCH_ACTIVE, true, 1154);
         set(ConfPaths.BLOCKPLACE_SCAFFOLD_PITCH_DIFFERENCE, 20, 1154);
         set(ConfPaths.BLOCKPLACE_SCAFFOLD_TOOLSWITCH, true, 1154);
-        set(ConfPaths.BLOCKPLACE_SCAFFOLD_ACTIONS, "vl>1 cancel vl>10 cancel log:scaffold:3:7:if vl>60 cancel log:scaffold:1:2:if cmd:clearscaffold:0:5", 1154);
-
+        set(ConfPaths.BLOCKPLACE_SCAFFOLD_ACTIONS, "vl>2 cancel vl>10 cancel log:scaffold:3:7:if vl>60 cancel log:scaffold:0:5:if cmd:clearscaffold:0:1 cmdc:kickscaffold:0:1", 1154);
+        // Speed
         set(ConfPaths.BLOCKPLACE_SPEED_CHECK, "default", 785);
-        set(ConfPaths.BLOCKPLACE_SPEED_INTERVAL, 30L, 1154); // Old limit: 45L < FPs with throwable potions.
+        set(ConfPaths.BLOCKPLACE_SPEED_INTERVAL, 35L, 1154); // Old limit: 45L < FPs with throwable potions.
         set(ConfPaths.BLOCKPLACE_SPEED_IMPROBABLE_FEEDONLY, true, 1154);
         set(ConfPaths.BLOCKPLACE_SPEED_IMPROBABLE_WEIGHT, 0.3, 1154);
         set(ConfPaths.BLOCKPLACE_SPEED_ACTIONS, "cancel vl>100 log:bpspeed:6:7:i cancel vl>1000 log:bpspeed:3:5:if cancel", 1154);
-
+        // Misc preventions
         set(ConfPaths.BLOCKPLACE_PREVENTMISC_BOATSANYWHERE, true);
+
 
         /* Chat */
         set(ConfPaths.CHAT_ACTIVE, "default", 1144);
-
         // Captcha.
         set(ConfPaths.CHAT_CAPTCHA_CHECK, "false", 1154);
         set(ConfPaths.CHAT_CAPTCHA_SKIP_COMMANDS, false, 785);
-        set(ConfPaths.CHAT_CAPTCHA_CHARACTERS, "abcdefghjkmnpqrtuvwxyzABCDEFGHJKMNPQRTUVWXYZ2346789!?><", 1154);
+        set(ConfPaths.CHAT_CAPTCHA_CHARACTERS, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!?><", 1154);
         set(ConfPaths.CHAT_CAPTCHA_LENGTH, 6, 785);
         set(ConfPaths.CHAT_CAPTCHA_QUESTION, "&c&l(!)&7 Please type '&6[captcha]&7' to continue using chat.", 1154);
         set(ConfPaths.CHAT_CAPTCHA_SUCCESS, "&c&l(!)&7 Antispam check passed.", 1154);
         set(ConfPaths.CHAT_CAPTCHA_TRIES, 3, 785);
         set(ConfPaths.CHAT_CAPTCHA_ACTIONS, "cancel cmdc:kickcaptcha vl>4 log:captcha:2:5:cf cancel cmdc:kickcaptcha", 785);
-        // This check should be subject to removal
-        set(ConfPaths.CHAT_COLOR_CHECK, "false", 1154);
+        // Color, legacy
+        set(ConfPaths.CHAT_COLOR_CHECK, false, 1154);
         set(ConfPaths.CHAT_COLOR_ACTIONS, "cancel", 1154);
-
-
+        // Commands
         set(ConfPaths.CHAT_COMMANDS_CHECK, "default", 785);
         set(ConfPaths.CHAT_COMMANDS_EXCLUSIONS, Arrays.asList("undo", "redo"), 1154);
         set(ConfPaths.CHAT_COMMANDS_HANDLEASCHAT, Arrays.asList("me", "msg", "emsg", "essentials:msg", "tell", "etell", "essentials:tell", "say", "esay", "essentials:say", "whisper", "ewhisper", "essentials:whisper", "w", "essentials:w", "ew", "r", "er", "essentials:r", "reply", "essentials:reply", "ereply"), 1154);
@@ -239,8 +241,8 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.CHAT_COMMANDS_SHORTTERM_TICKS, 18, 785);
         set(ConfPaths.CHAT_COMMANDS_SHORTTERM_LEVEL, 3, 785);
         set(ConfPaths.CHAT_COMMANDS_ACTIONS, "log:commands:0:5:cf cancel cmdc:kickcommands vl>20 log:commands:0:5:cf cancel cmdc:tempkick1", 1154);
-
         // Text (ordering on purpose).
+        // Normal
         set(ConfPaths.CHAT_TEXT_CHECK, "default", 785);
         set(ConfPaths.CHAT_TEXT_ALLOWVLRESET, true, 785);
         set(ConfPaths.CHAT_TEXT_FREQ_NORM_MIN, 0.0, 785);
@@ -248,7 +250,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.CHAT_TEXT_FREQ_NORM_WEIGHT, 6, 785);
         set(ConfPaths.CHAT_TEXT_FREQ_NORM_LEVEL, 160, 785);
         set(ConfPaths.CHAT_TEXT_FREQ_NORM_ACTIONS, "cancel cmdc:tellchatnormal vl>7 log:chatnormal:0:5:cif cancel cmdc:tellchatnormal vl>20 log:chatnormal:0:5:cif cancel cmdc:kickchatnormal vl>40 log:chatnormal:0:5:cif cancel cmdc:kickchat5", 1154);
-                                                    
+        // ShortTerm                                      
         set(ConfPaths.CHAT_TEXT_FREQ_SHORTTERM_MIN, 2.0, 785);
         set(ConfPaths.CHAT_TEXT_FREQ_SHORTTERM_FACTOR, 0.7, 785);
         set(ConfPaths.CHAT_TEXT_FREQ_SHORTTERM_WEIGHT, 3.0, 785);
@@ -299,82 +301,78 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.CHAT_LOGINS_LIMIT, 10, 785);
         set(ConfPaths.CHAT_LOGINS_KICKMESSAGE, "Too many players are logging in at the same time, please try again later.", 1154);
 
-        /*
-         * Combined !
-         */
 
+        /* Combined */
         set(ConfPaths.COMBINED_ACTIVE, "default", 1144);
-
+        // BedLeave
         set(ConfPaths.COMBINED_BEDLEAVE_CHECK, "default", 785);
-        set(ConfPaths.COMBINED_BEDLEAVE_ACTIONS, "cancel log:bedleave:0:5:if cmdc:kickbedleave", 1154);
-
-        set(ConfPaths.COMBINED_ENDERPEARL_CHECK, true, 1154); // 'default' activation flag issue
+        set(ConfPaths.COMBINED_BEDLEAVE_ACTIONS, "cancel log:bedleave:0:5:if cmdc:kickbedleave:0:1", 1154);
+        // Enderpearl
+        set(ConfPaths.COMBINED_ENDERPEARL_CHECK, true, 1154); // 'default' activation flag bug
         set(ConfPaths.COMBINED_ENDERPEARL_PREVENTCLICKBLOCK, true, 785);
-
+        // Improbable
         set(ConfPaths.COMBINED_IMPROBABLE_CHECK , "default", 785);
-        set(ConfPaths.COMBINED_IMPROBABLE_LEVEL, 300, 785);
-        //        set(ConfPaths.COMBINED_IMPROBABLE_FASTBREAK_CHECK, false, 785);
-        set(ConfPaths.COMBINED_IMPROBABLE_ACTIONS, "cancel vl>10 log:improbable:8:9:if cancel vl>1500 cancel log:improbable:0:10:if cmdc:kickimprobable:0:10 cmdc:clearimprobable:0:10", 1154);
-
+        set(ConfPaths.COMBINED_IMPROBABLE_LEVEL, 250, 1154);
+        set(ConfPaths.COMBINED_IMPROBABLE_ACTIONS, "cancel vl>10 log:improbable:8:9:if cancel vl>1500 cancel log:improbable:0:10:if cmd:clearimprobable:0:10 cmdc:kickimprobable:0:5", 1154);
+        // Invulnerable
         set(ConfPaths.COMBINED_INVULNERABLE_CHECK, true, 785); // Not a check type yet.
         set(ConfPaths.COMBINED_INVULNERABLE_TRIGGERS_ALWAYS, false, 785);
         set(ConfPaths.COMBINED_INVULNERABLE_TRIGGERS_FALLDISTANCE, true, 785);
         set(ConfPaths.COMBINED_INVULNERABLE_INITIALTICKS_JOIN, -1, 785);
         set(ConfPaths.COMBINED_INVULNERABLE_IGNORE, Arrays.asList("FALL"), 785);
         set(ConfPaths.COMBINED_INVULNERABLE_MODIFIERS + ".all", 0, 785);
-
+        // Munchhausen
         set(ConfPaths.COMBINED_MUNCHHAUSEN_CHECK, "default", 785);
         set(ConfPaths.COMBINED_MUNCHHAUSEN_ACTIONS, "cancel vl>100 cancel log:munchhausen:0:60:if", 785);
-
-        // (No active flag set !?)
-        set(ConfPaths.COMBINED_YAWRATE_RATE , 290, 1154); // Old limit: 360
-        set(ConfPaths.COMBINED_YAWRATE_PENALTY_FACTOR, 2.0, 1154); // 1.0
+        // YawRate settings
+        set(ConfPaths.COMBINED_YAWRATE_RATE , 290, 1154); // 360
+        set(ConfPaths.COMBINED_YAWRATE_PENALTY_FACTOR, 2.0, 1154); 
         set(ConfPaths.COMBINED_YAWRATE_PENALTY_MIN, 450, 1154); // 250
         set(ConfPaths.COMBINED_YAWRATE_PENALTY_MAX, 2500, 1154); // 1500
         set(ConfPaths.COMBINED_YAWRATE_IMPROBABLE_FEEDONLY, false, 1154);
         set(ConfPaths.COMBINED_YAWRATE_IMPROBABLE_WEIGHT, 90.0, 1154); // 100.0
-        // set(ConfPaths.COMBINED_YAWRATE_IMPROBABLE, true, 785);
 
-        // FIGHT
+
+        /* Fight */
         set(ConfPaths.FIGHT_ACTIVE, "default", 1144);
-
+        // General
         set(ConfPaths.FIGHT_CANCELDEAD, true, 785);
-		set(ConfPaths.FIGHT_MAXLOOPLETENCYTICKS, 8, 1154);
+	set(ConfPaths.FIGHT_MAXLOOPLETENCYTICKS, 8, 1154);
         set(ConfPaths.FIGHT_TOOLCHANGEPENALTY, 0L, 1154); // Disabled for now, it interferes too much with pvp. 500L
         set(ConfPaths.FIGHT_PVP_KNOCKBACKVELOCITY, "default", 785);
-
-        set(ConfPaths.FIGHT_YAWRATE_CHECK, true, 785); // Not a check type.
-
+        // YawRate activation flag
+        set(ConfPaths.FIGHT_YAWRATE_CHECK, true, 785); 
+        // Angle
         set(ConfPaths.FIGHT_ANGLE_CHECK, "default", 785);
-        set(ConfPaths.FIGHT_ANGLE_THRESHOLD_MOVE, 100, 1154); // Move is problematic with mob grinders and in a 2 VS 1 scenario.
-        set(ConfPaths.FIGHT_ANGLE_THRESHOLD_TIME, 200, 1154); // Time is problematic with mob grinders and in a 2 VS 1 scenario.
+        set(ConfPaths.FIGHT_ANGLE_THRESHOLD_MOVE, 100, 1154);
+        set(ConfPaths.FIGHT_ANGLE_THRESHOLD_TIME, 150, 1154); 
         set(ConfPaths.FIGHT_ANGLE_THRESHOLD_YAW, 60, 1154); 
         set(ConfPaths.FIGHT_ANGLE_THRESHOLD_SWITCH, 50, 1153);
-        set(ConfPaths.FIGHT_ANGLE_ACTIONS, "cancel vl>100 log:angle:4:5:i cancel vl>500 log:angle:0:20:if cancel", 1154);
-
+        set(ConfPaths.FIGHT_ANGLE_ACTIONS, "cancel vl>100 log:angle:6:5:i cancel vl>800 log:angle:0:20:if cancel", 1154);
+        // Critical
         set(ConfPaths.FIGHT_CRITICAL_CHECK, "default", 785);
-        // Old value: 0.06251. NCP seems to be unable to catch packet-critical cheats with this value, although it has nearly no false positives.
-        set(ConfPaths.FIGHT_CRITICAL_FALLDISTANCE, 0.075, 785); 
-        set(ConfPaths.FIGHT_CRITICAL_ACTIONS, "vl>2 cancel vl>50 cancel log:critical:10:9:i vl>100 cancel cmd:clearcritical:0:10", 1154);
-
+        set(ConfPaths.FIGHT_CRITICAL_FALLDISTANCE, 0.075, 1154); 
+        set(ConfPaths.FIGHT_CRITICAL_ACTIONS, "vl>1 cancel vl>5 cancel log:critical:6:10:i vl>60 cancel log:critical:0:5:icf cmdc:kickcritical:0:2", 1154);
+        // Direction
         set(ConfPaths.FIGHT_DIRECTION_CHECK, "default", 785);
         set(ConfPaths.FIGHT_DIRECTION_STRICT, true, 1154);
-		set(ConfPaths.FIGHT_DIRECTION_FAILALL, true, 1154);
+	set(ConfPaths.FIGHT_DIRECTION_FAILALL, true, 1154);
         set(ConfPaths.FIGHT_DIRECTION_PENALTY, 75L, 1154);
-        set(ConfPaths.FIGHT_DIRECTION_ACTIONS, "vl>2 log:fdirectionlowvl:9:10:i vl>5 log:fdirectionlowvl:5:4:i vl>10 cancel log:fdirection:2:4:if vl>50 cancel log:fdirection:0:7:icf cmdc:kicksuspiciouscombat:1:5", 1154);
-
+        set(ConfPaths.FIGHT_DIRECTION_ACTIONS, "vl>2 log:fdirectionlowvl:5:6:i vl>10 cancel log:fdirection:2:4:if vl>50 cancel log:fdirection:0:7:icf cmdc:kicksuspiciouscombat:1:5", 1154);
+        // FastHeal, legacy
         set(ConfPaths.FIGHT_FASTHEAL_CHECK, "default", 785);
         set(ConfPaths.FIGHT_FASTHEAL_INTERVAL, 4000L, 785);
         set(ConfPaths.FIGHT_FASTHEAL_BUFFER, 1000L, 785);
         set(ConfPaths.FIGHT_FASTHEAL_ACTIONS, "cancel vl>10 cancel log:fastheal:2:6:i vl>30 cancel log:fastheal:1:1:i vl>90 cancel log:fastheal:0:10:if cmdc:kickfastheal:0:10", 1154);
-
+        // GodMode
         set(ConfPaths.FIGHT_GODMODE_CHECK, "default", 785);
         set(ConfPaths.FIGHT_GODMODE_LAGMINAGE, 1100, 785); // TODO: ndt/2 => 500-600.
         set(ConfPaths.FIGHT_GODMODE_LAGMAXAGE, 5000, 785);
         set(ConfPaths.FIGHT_GODMODE_ACTIONS, "cancel log:godmode:0:5:icf cmdc:kickgod:0:5", 1154);
-
+        // NoSwing
         set(ConfPaths.FIGHT_NOSWING_CHECK, "default", 785);
-        set(ConfPaths.FIGHT_NOSWING_ACTIONS, "vl>2 cancel vl>10 log:noswing:1:5:i cancel", 1154);
+        set(ConfPaths.FIGHT_NOSWING_ACTIONS, "vl>2 cancel vl>10 log:noswing:2:5:i cancel", 1154);
+        // PitchPattern
         // TODO: Merge @CaptainObvious' pitchpattern check in this fork.
         //set(ConfPaths.FIGHT_PITCHPATTERN_CHECK, "default", 1153);
         //set(ConfPaths.FIGHT_PITCHPATTERN_ALWAYSACTIVE, false, 1154); // <- Cinematic/Zoom-like mods issue.
@@ -383,7 +381,7 @@ public class DefaultConfig extends ConfigFile {
         //set(ConfPaths.FIGHT_PITCHPATTERN_DIFF, 0.001D, 1153);
         //set(ConfPaths.FIGHT_PITCHPATTERN_DELTAGCD, 0.00001F, 1153);
         //set(ConfPaths.FIGHT_PITCHPATTERN_ACTIONS, "vl>2 cancel vl>10 cancel log:pitchpattern:5:6:i vl>100 cancel log:pitchpattern:0:10:icf cmdc:kickillegalrotations:3:10", 1154);
-
+        // Reach
         set(ConfPaths.FIGHT_REACH_CHECK, "default", 785);
         set(ConfPaths.FIGHT_REACH_SURVIVALDISTANCE, 4.22, 1154); // 4.4 
         set(ConfPaths.FIGHT_REACH_PENALTY, 250, 1154);
@@ -392,28 +390,29 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.FIGHT_REACH_REDUCESTEP, 0.15, 785);
         set(ConfPaths.FIGHT_REACH_IMPROBABLE_FEEDONLY, false, 1154);
         set(ConfPaths.FIGHT_REACH_IMPROBABLE_WEIGHT, 2.0, 1154);
-        set(ConfPaths.FIGHT_REACH_ACTIONS, "vl>1 log:freach:8:9:i vl>5 cancel log:freach:2:6:if vl>12 cancel log:kreach:1:5:i vl>35 cancel log:kreach:0:5:if cmdc:kicksuspiciouscombat:2:1", 1154);
-
+        set(ConfPaths.FIGHT_REACH_ACTIONS, "vl>1 log:freach:8:9:i vl>5 cancel log:freach:2:6:if vl>12 cancel log:freachhighvl:1:5:i vl>35 cancel log:freachhighvl:0:5:if cmdc:kicksuspiciouscombat:2:1", 1154);
+        // SelfHit, legacy
         set(ConfPaths.FIGHT_SELFHIT_CHECK, "default", 785);
-		set(ConfPaths.FIGHT_SELFHIT_EXCLUDEPROJECTILE, false, 1154);
+	set(ConfPaths.FIGHT_SELFHIT_EXCLUDEPROJECTILE, false, 1154);
         set(ConfPaths.FIGHT_SELFHIT_ACTIONS, "cancel log:fselfhit:0:5:icf cmdc:kickselfhit:0:5", 1154);
-
+        // Speed
         set(ConfPaths.FIGHT_SPEED_CHECK, "default", 785);
         set(ConfPaths.FIGHT_SPEED_LIMIT, 15, 1154); 
-        set(ConfPaths.FIGHT_SPEED_ACTIONS, "cancel vl>20 cancel log:fspeed:2:5:i vl>80 cancel log:fspeed:1:1:if cmd:kickattackfrequency:0:10", 1154);
+        set(ConfPaths.FIGHT_SPEED_ACTIONS, "cancel vl>10 cancel log:fspeed:2:5:i vl>60 cancel log:fspeed:0:5:if cmdc:kickattackfrequency:0:10", 1154);
         set(ConfPaths.FIGHT_SPEED_SHORTTERM_TICKS, 7, 785);
         set(ConfPaths.FIGHT_SPEED_SHORTTERM_LIMIT, 5, 1154);
         set(ConfPaths.FIGHT_SPEED_IMPROBABLE_FEEDONLY, false, 1154);
         set(ConfPaths.FIGHT_SPEED_IMPROBABLE_WEIGHT, 2.0, 1154);
 
 
+        /* Inventory */
         set(ConfPaths.INVENTORY_ACTIVE, "default", 1144);
-
+        // Drop, legacy.
         set(ConfPaths.INVENTORY_DROP_CHECK, "default", 785);
         set(ConfPaths.INVENTORY_DROP_LIMIT, 10, 1154);
         set(ConfPaths.INVENTORY_DROP_TIMEFRAME, 20L, 785);
         set(ConfPaths.INVENTORY_DROP_ACTIONS, "log:drop:0:5:if cancel cmdc:dropkick:0:5", 1154);
-
+        // FastClick
         set(ConfPaths.INVENTORY_FASTCLICK_CHECK, "default", 785);
         set(ConfPaths.INVENTORY_FASTCLICK_EXCLUDE, Arrays.asList("Inventory Name Here"), 1154);
         set(ConfPaths.INVENTORY_FASTCLICK_SPARECREATIVE, true, 785);
@@ -422,44 +421,44 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.INVENTORY_FASTCLICK_LIMIT_NORMAL, 15, 785);
         set(ConfPaths.INVENTORY_FASTCLICK_LIMIT_CHEST, 155, 1154);
         set(ConfPaths.INVENTORY_FASTCLICK_IMPROBABLE_WEIGHT, 0.7, 1154);
-        set(ConfPaths.INVENTORY_FASTCLICK_ACTIONS, "cancel vl>200 cancel log:fastclick:7:5:i vl>600 cancel log:fastclick:1:5:if vl>5000 cancel log:fastclick:1:2:if cmdc:kickfastclick:2:15", 1154);
-
+        set(ConfPaths.INVENTORY_FASTCLICK_ACTIONS, "cancel vl>150 cancel log:fastclick:7:5:i vl>400 cancel log:fastclick:1:5:if vl>3000 cancel log:fastclick:1:2:if cmdc:kickfastclick:2:5", 1154);
+        // InstantBow
         set(ConfPaths.INVENTORY_INSTANTBOW_CHECK, "default", 785);
         set(ConfPaths.INVENTORY_INSTANTBOW_STRICT, true, 785);
         set(ConfPaths.INVENTORY_INSTANTBOW_DELAY, 75, 1154);
         set(ConfPaths.INVENTORY_INSTANTBOW_IMPROBABLE_FEEDONLY, false, 1085);
         set(ConfPaths.INVENTORY_INSTANTBOW_IMPROBABLE_WEIGHT, 0.6, 1085);
         set(ConfPaths.INVENTORY_INSTANTBOW_ACTIONS, "cancel vl>15 cancel log:instantbow:4:5:i vl>200 cancel log:instantbow:0:10:if cmdc:kickbow:2:10", 1154);
-
-        // TODO: Set this to false as default?
-        set(ConfPaths.INVENTORY_INSTANTEAT_CHECK, "default", 785);
+        // InstantEat, legacy. Disabled since it seems to interfer with FastConsume somehow... 
+        set(ConfPaths.INVENTORY_INSTANTEAT_CHECK, false, 1154); 
         set(ConfPaths.INVENTORY_INSTANTEAT_ACTIONS, "log:instanteat:2:5:i cancel", 1154);
-
+        // FastConsume
         set(ConfPaths.INVENTORY_FASTCONSUME_CHECK, "default", 785);
         set(ConfPaths.INVENTORY_FASTCONSUME_DURATION, 1.4, 1154); // The actual consumption time needed would be 1.5s. Set to 1.4 for leniency
         set(ConfPaths.INVENTORY_FASTCONSUME_WHITELIST, false, 785);
-        set(ConfPaths.INVENTORY_FASTCONSUME_ITEMS, Arrays.asList("DRIED_KELP"), 1154);
+        set(ConfPaths.INVENTORY_FASTCONSUME_ITEMS, Bridge1_13.hasIsSwimming() ? Arrays.asList("DRIED_KELP") : new LinkedList<String>(), 1154); // Quick way to check if the server is 1.13+
         set(ConfPaths.INVENTORY_FASTCONSUME_ACTIONS, "cancel vl>2 log:fastconsume:2:5:if cancel vl>35 cancel log:fastconsume:0:5:if cmdc:kickfastconsume:0:5", 1154);
-        
+        // InvMove
         set(ConfPaths.INVENTORY_INVENTORYMOVE_CHECK, "default", 1153);
         set(ConfPaths.INVENTORY_INVENTORYMOVE_DISABLECREATIVE, true, 1153);
         set(ConfPaths.INVENTORY_INVENTORYMOVE_HDISTLENIENCY, 0.005, 1153);
         set(ConfPaths.INVENTORY_INVENTORYMOVE_HDISTMIN, 0.1, 1153);
         set(ConfPaths.INVENTORY_INVENTORYMOVE_ACTIONS, "log:inventorymove:2:5:i cancel", 1154);
-
+        // Gutenberg
         set(ConfPaths.INVENTORY_GUTENBERG_CHECK, "default", 785);
         set(ConfPaths.INVENTORY_GUTENBERG_PAGELIMIT, 50, 1154);
         set(ConfPaths.INVENTORY_GUTENBERG_ACTIONS, "cancel log:gutenberg:0:10:if cmdc:kickinvaliddata:0:5", 1154);
-
+        // Items
         set(ConfPaths.INVENTORY_ITEMS_CHECK, "default", 785);
-
+        // Open
         set(ConfPaths.INVENTORY_OPEN_CHECK, "default", 785);
         set(ConfPaths.INVENTORY_OPEN_CLOSE, true, 785);
         set(ConfPaths.INVENTORY_OPEN_CANCELOTHER, true, 785);
+        // Hotfix 1.9+
+        set(ConfPaths.INVENTORY_HOTFIX_DUPE_FALLINGBLOCKENDPORTAL, true, 785);
 
-        set (ConfPaths.INVENTORY_HOTFIX_DUPE_FALLINGBLOCKENDPORTAL, true, 785);
 
-        /* Moving ! */
+        /* Moving */
         set(ConfPaths.MOVING_ACTIVE, "default", 1144);
         // CreativeFly
         set(ConfPaths.MOVING_CREATIVEFLY_CHECK, "default", 785);
@@ -500,13 +499,14 @@ public class DefaultConfig extends ConfigFile {
             set(ConfPaths.MOVING_CREATIVEFLY_MODEL + "elytra." + ConfPaths.SUB_VERTICAL_MAXHEIGHT, 128, 1104);
             set(ConfPaths.MOVING_CREATIVEFLY_MODEL + "elytra." + ConfPaths.SUB_MODIFIERS, false, 785);
 			set(ConfPaths.MOVING_CREATIVEFLY_EYTRA_FWRESET, false, 1154);
-            set(ConfPaths.MOVING_CREATIVEFLY_EYTRA_STRICT, false, 1154);
+            set(ConfPaths.MOVING_CREATIVEFLY_EYTRA_STRICT, true, 1154);
         }
+        // TODO: Let CreativeFly handle ripditing as well, instead of SurvivalFly.
         set(ConfPaths.MOVING_CREATIVEFLY_ACTIONS,
                 "cancel log:flyfile:3:5:f"
                         + " vl>100 cancel log:creativefly:8:9:i log:flyfile:0:10:f"
                         + " vl>900 cancel log:creativefly:2:4:i log:flyfile:0:5:cf"
-                        + " vl>2000 cancel log:creativefly:0:5:icf cmdc:kickfly:0:15 cmd:clearcf:0:15"
+                        + " vl>2000 cancel log:creativefly:0:5:icf cmd:clearcf:0:15 cmdc:kickfly:0:15"
                         , 1154);
         // MorePackets
         set(ConfPaths.MOVING_MOREPACKETS_CHECK, "default", 785);
@@ -517,7 +517,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_MOREPACKETS_BURST_DIRECT, 60, 785);
         set(ConfPaths.MOVING_MOREPACKETS_BURST_EPM, 120, 1154);
         set(ConfPaths.MOVING_MOREPACKETS_SETBACKAGE, 70, 1154); // 40
-        set(ConfPaths.MOVING_MOREPACKETS_ACTIONS, "cancel vl>2 cancel log:morepackets:10:9:i vl>100 cancel log:morepackets:0:2:ifc cmdc:kickpackets:2:10", 1154);
+        set(ConfPaths.MOVING_MOREPACKETS_ACTIONS, "cancel vl>2 cancel log:morepackets:10:9:i vl>100 cancel log:morepackets:0:2:ifc cmdc:kickpackets:0:10", 1154);
         // NoFall
         set(ConfPaths.MOVING_NOFALL_CHECK, "default", 785);
         set(ConfPaths.MOVING_NOFALL_DEALDAMAGE, true, 785);
@@ -533,20 +533,20 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_PASSABLE_UNTRACKED_TELEPORT_ACTIVE, true, 785);
         set(ConfPaths.MOVING_PASSABLE_UNTRACKED_CMD_ACTIVE, true, 785);
         set(ConfPaths.MOVING_PASSABLE_UNTRACKED_CMD_TRYTELEPORT, true, 785);
-        set(ConfPaths.MOVING_PASSABLE_UNTRACKED_CMD_PREFIXES, Arrays.asList("sethome", "home set", "setwarp", "warp set", "setback", "set back", "back set", "warp", "home", "tp" ), 1154);
+        set(ConfPaths.MOVING_PASSABLE_UNTRACKED_CMD_PREFIXES, Arrays.asList("sethome", "home set", "setwarp", "warp set", "setback", "set back", "back set", "warp", "home", "tp", "tpa", "tpask"), 1154);
         // SurvivalFly
         set(ConfPaths.MOVING_SURVIVALFLY_CHECK, "default", 785);
         set(ConfPaths.MOVING_SURVIVALFLY_STEPHEIGHT, "default", 785);
         set(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_VACC, true, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_HBUFMAX, 0.5, 1154);
-        // SurvivalFly ViolationFrequencyHook
+        // SurvivalFly - ViolationFrequencyHook
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_ACTIVE, true, 1154);
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_DEBUG, false, 1154);
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_MAXTOTALVLS, 35, 1154);
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_MINADDEDVLS, 5, 1154);
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_MOREVLS, 5, 1154);
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_MOVECOUNT, 10, 1154);
-
+        // More leniency features
         set(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZECOUNT, 40, 1144);
         set(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR, true, 1143);
         set(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE, true, 785);
@@ -556,24 +556,21 @@ public class DefaultConfig extends ConfigFile {
             + " vl>300 cancel log:survivalfly:7:8:i log:flyfile:1:3:f" 
             + " vl>830 cancel log:survivalflyhighvl:4:9:i log:flyfile:2:3:f" 
             + " vl>1500 cancel log:survivalflyhighvl:3:4:i log:flyfile:1:2:f" 
-            + " vl>2100 cancel log:survivalflyhighvl:0:4:icf cmdc:kickfly:0:15 cmd:clearsf:0:15", 1154);     
+            + " vl>2100 cancel log:survivalflyhighvl:0:4:icf cmd:clearsf:0:15 cmdc:kickfly:0:15", 1154);     
         // SurvivalFly - Hover Subcheck
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_CHECK, true, 785); // Not a check type yet.
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_STEP, 5, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_TICKS, 85, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_LOGINTICKS, 60, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_FALLDAMAGE, true, 785);
-        set(ConfPaths.MOVING_SURVIVALFLY_HOVER_SFVIOLATION, 200, 1154); // Old VL: 500
-
+        set(ConfPaths.MOVING_SURVIVALFLY_HOVER_SFVIOLATION, 200, 1154); 
         // Moving Trace
         //set(ConfPaths.MOVING_TRACE_MAXAGE, 200, 785); // Your grandma reads code.
         //set(ConfPaths.MOVING_TRACE_MAXSIZE, 200, 785);
-
         // Velocity.
         set(ConfPaths.MOVING_VELOCITY_ACTIVATIONCOUNTER, 80, 785);
         set(ConfPaths.MOVING_VELOCITY_ACTIVATIONTICKS, 140, 785);
         set(ConfPaths.MOVING_VELOCITY_STRICTINVALIDATION, true, 785);
-
         // General.
         set(ConfPaths.MOVING_SPLITMOVES, "default", 785);
         set(ConfPaths.MOVING_IGNORESTANCE, "default", 785);
@@ -588,28 +585,26 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_ENFORCELOCATION, "default", 785);
         set(ConfPaths.MOVING_SETBACK_METHOD, "default", 785);
 
-        // Vehicles.
+
+        /* Vehicles settings */
         set(ConfPaths.MOVING_VEHICLE_PREVENTDESTROYOWN, true, 785);
         set(ConfPaths.MOVING_VEHICLE_ENFORCELOCATION, "default", 785);
         set(ConfPaths.MOVING_VEHICLE_SCHEDULESETBACKS, "default", 785);
-
+        // VehicleMorePackets
         set(ConfPaths.MOVING_VEHICLE_MOREPACKETS_CHECK, "default", 785);
         set(ConfPaths.MOVING_VEHICLE_MOREPACKETS_ACTIONS, "cancel vl>2 log:morepackets:2:5:if cancel vl>100 cancel log:morepackets:1:2:if cmdc:kickpackets:2:10", 1154);
-
+        // VehicleEnvelope check
         set(ConfPaths.MOVING_VEHICLE_ENVELOPE_ACTIVE, "default", 785);
         set(ConfPaths.MOVING_VEHICLE_ENVELOPE_HSPEEDCAP + ".default", 0.9, 1154);
         set(ConfPaths.MOVING_VEHICLE_ENVELOPE_HSPEEDCAP + ".pig", 0.3, 1154);
-        set(ConfPaths.MOVING_VEHICLE_ENVELOPE_ACTIONS, "cancel vl>50 cancel log:vehicleenvelope:10:6:if vl>300 cancel log:vehicleenvelope:0:10:icf cmdc:kickvehiclefly:0:10 cmd:clearvehicle:0:15", 1154);
-
+        set(ConfPaths.MOVING_VEHICLE_ENVELOPE_ACTIONS, "cancel vl>50 cancel log:vehicleenvelope:10:6:if vl>300 cancel log:vehicleenvelope:0:10:if cmd:clearvehicle:0:15 cmdc:kickvehiclefly:0:10", 1154);
         // Messages
         set(ConfPaths.MOVING_MESSAGE_ILLEGALPLAYERMOVE, "Illegal move.", 785);
         set(ConfPaths.MOVING_MESSAGE_ILLEGALVEHICLEMOVE, "Illegal vehicle move.", 785);
 
 
         /* Net */
-
         set(ConfPaths.NET_ACTIVE, "default", 1144);
-
         // AttackFrequency
         set(ConfPaths.NET_ATTACKFREQUENCY_ACTIVE, "default", 785);
         set(ConfPaths.NET_ATTACKFREQUENCY_SECONDS_HALF, 8, 1154); // 10
@@ -619,7 +614,6 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.NET_ATTACKFREQUENCY_SECONDS_EIGHT, 95, 1154); //100
         set(ConfPaths.NET_ATTACKFREQUENCY_IMPROBABLE_WEIGHT, 3.0, 1154);
         set(ConfPaths.NET_ATTACKFREQUENCY_ACTIONS, "cancel vl>10 cancel log:attackfrequency:4:5:i vl>200 cancel log:attackfrequency:0:4:if cmdc:kickattackfrequency", 1154);
-        
         // FlyingFrequency
         set(ConfPaths.NET_FLYINGFREQUENCY_ACTIVE, "default", 785);
         set(ConfPaths.NET_FLYINGFREQUENCY_SECONDS, 5, 785);
@@ -628,32 +622,28 @@ public class DefaultConfig extends ConfigFile {
         // but they will still be able to move client-side; this will result in a server-sided freeze.
         // When the player thaws out of this state, (presumably) their position will update in a rather fast sequence, which SurvivalFly
         // really seems to dislike. (Players can sometimes reach 1000+ VLs(!))
-        // Thus, lower Flyingfrequency violation should not be immediately canceled, 20 seems a reasonable threshold through testing.
+        // Thus, lower Flyingfrequency violations should not be immediately canceled, 20 seems a reasonable threshold through testing.
         set(ConfPaths.NET_FLYINGFREQUENCY_ACTIONS, "vl>20 cancel log:flyingfrequency:3:2:i vl>500 cancel log:flyingfrequency:0:5:if vl>1000 cancel log:flyingfrequency:0:2:icf cmdc:kickflyingfrequency:0:10", 1154); 
         set(ConfPaths.NET_FLYINGFREQUENCY_REDUNDANT_ACTIVE, true, 785);
         set(ConfPaths.NET_FLYINGFREQUENCY_REDUNDANT_SECONDS, 3, 785);
         set(ConfPaths.NET_FLYINGFREQUENCY_REDUNDANT_ACTIONS, "cancel", 785); 
-
         // KeepAliveFrequency
         set(ConfPaths.NET_KEEPALIVEFREQUENCY_ACTIVE, "default", 785);
         set(ConfPaths.NET_KEEPALIVEFREQUENCY_SECONDS, 20, 1153);
-        set(ConfPaths.NET_KEEPALIVEFREQUENCY_ACTIONS, "cancel vl>10 cancel log:keepalive:2:6:i vl>60 cancel log:keepalive:0:10:icf cmdc:kickalive", 1154);
-
+        set(ConfPaths.NET_KEEPALIVEFREQUENCY_ACTIONS, "cancel vl>10 cancel log:keepalive:2:6:i vl>60 cancel log:keepalive:0:10:icf cmdc:kickalive:0:5", 1154);
         // PacketFrequency (pre 1.9).
         set(ConfPaths.NET_PACKETFREQUENCY_ACTIVE, "default", 785);
         set(ConfPaths.NET_PACKETFREQUENCY_PPS, 300, 1154); // Old limit: 200, legit 1.8 clients seem to be able to reach such value more often than not...
         set(ConfPaths.NET_PACKETFREQUENCY_SECONDS, 4, 785);
-        set(ConfPaths.NET_PACKETFREQUENCY_ACTIONS, "cancel vl>2 cancel cmdc:kickpacketfrequency", 1154);
-
+        set(ConfPaths.NET_PACKETFREQUENCY_ACTIONS, "cancel vl>2 cancel cmdc:kickpacketfrequency:0:5", 1154);
         // SoundDistance
         set(ConfPaths.NET_SOUNDDISTANCE_ACTIVE, "default", 785);
         set(ConfPaths.NET_SOUNDDISTANCE_MAXDISTANCE, 320, 785);
-
         // Superseded
         set(ConfPaths.NET_SUPERSEDED_FLYING_CANCELWAITING, true, 1090);
-        
+        // WrongTurn
         set(ConfPaths.NET_WRONGTURN_ACTIVE, "default", 1154);
-        set(ConfPaths.NET_WRONGTURN_ACTIONS, "cancel cmdc:kickillegalrotations:0:10 log:wrongturn:0:15:i", 1154);
+        set(ConfPaths.NET_WRONGTURN_ACTIONS, "cancel log:wrongturn:0:15:icf cmdc:kickillegalrotations:0:10", 1154);
 
 
         // TODO: An extra file might suit these.
@@ -664,10 +654,10 @@ public class DefaultConfig extends ConfigFile {
         final String kick = "ncp kick [player] &c&l(!)&7 ";
         set(ConfPaths.STRINGS + ".against", start + "tried to place a block against liquid blocks or air as if they were solid" + end, 1154);
         set(ConfPaths.STRINGS + ".angle", start + "potentially tried to hit multiple entities at the same time (Tags: &6[tags]&7)" + end, 1154);
-        set(ConfPaths.STRINGS + ".attackfrequency", start + "seems to be using an autoclicker (Clicks: &6[packets]&7/LimitPerTime-frame:&7[limit]&7, &6[tags]&7)" + end, 1154);
+        set(ConfPaths.STRINGS + ".attackfrequency", start + "seems to be using an autoclicker (Clicks: &6[packets]&7/LimitPerTime-frame: &6[limit]&7, &6[tags]&7)" + end, 1154);
         set(ConfPaths.STRINGS + ".bautosign", start + "tried to use the autosign hack (Subcheck: &6[tags]&7)" + end, 1154);
         set(ConfPaths.STRINGS + ".bbfrequency", start + "tried to break too many blocks at once" + end, 1154);
-        set(ConfPaths.STRINGS + ".bdirection", start + "tried to interact with a block out of their line of sight" + end, 1154);
+        set(ConfPaths.STRINGS + ".bdirection", start + "tried to interact with a block outside their line of sight" + end, 1154);
         set(ConfPaths.STRINGS + ".bedleave", start + "tried to send fake bed leave packets (was not in/near a bed)" + end, 1154);
         set(ConfPaths.STRINGS + ".bpspeed", start + "tried to throw projectiles too quickly" + end, 1154);
         set(ConfPaths.STRINGS + ".breach", start + "tried to interact with a block too far away" + end, 1154);
@@ -685,7 +675,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.STRINGS + ".fastbreak", start + "tried to break a block faster than possible (Block: &6[blocktype]&7)" + end, 1154);
         set(ConfPaths.STRINGS + ".fastclick", start + "tried to move items in their inventory too quickly" + end, 785);
         set(ConfPaths.STRINGS + ".fastconsume", start + "tried to consume an item too quickly (Food: &6[food][tags]&7)" + end, 1154);
-        set(ConfPaths.STRINGS + ".fastheal", start + "tried to regenerate their health bar faster than possible (Health: &6health]&7)" + end, 1154);
+        set(ConfPaths.STRINGS + ".fastheal", start + "tried to regenerate their health bar faster than possible (Health: &6[health]&7)" + end, 1154);
         set(ConfPaths.STRINGS + ".fastplace", start + "tried to place blocks too quickly" + end, 1154);
         set(ConfPaths.STRINGS + ".fdirection", start + "tried to hit an entity outside their line of sight" + end, 1154);
         set(ConfPaths.STRINGS + ".fdirectionlowvl", start + "could be using an aimbot (hit not canceled)" + end, 1154);
@@ -713,6 +703,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.STRINGS + ".kickchatfast", kick + "Stop spamming.", 1154);
         set(ConfPaths.STRINGS + ".kickchatnormal", kick + "Too many chat messages, take a break.", 1154);
         set(ConfPaths.STRINGS + ".kickcommands", "ncp tempkick [player] 1 &c&l(!)&7 Do not spam commands (1 minute tempkick)", 1154);
+        set(ConfPaths.STRINGS + ".kickcritical", kick + "Incorrect movements (Critical cheats?)", 1154);
         set(ConfPaths.STRINGS + ".kickfastbreak", kick + "Breaking blocks too fast.", 1154);
         set(ConfPaths.STRINGS + ".kickfastclick", kick + "Unlikely inventory interactions.", 1154);
         set(ConfPaths.STRINGS + ".kickfastconsume", kick + "Using items too quickly.", 1154);
@@ -728,12 +719,12 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.STRINGS + ".kickinvaliddata", kick + "Invalid book data.", 1154);
         set(ConfPaths.STRINGS + ".kickpacketfrequency", kick + "Too many packets.", 1154);
         set(ConfPaths.STRINGS + ".kickpackets", kick + "You sent too many moves (extreme lag?)", 1154);
-        set(ConfPaths.STRINGS + ".kickscaffold", kick + "Incorrect block placements.", 1154);
+        set(ConfPaths.STRINGS + ".kickscaffold", kick + "Unnatural block placements.", 1154);
         set(ConfPaths.STRINGS + ".kickselfhit", kick + "You tried to hit yourself!", 1154);
         set(ConfPaths.STRINGS + ".kicksuspiciouscombat", kick + "Illegal combat modifications.", 1154); 
         set(ConfPaths.STRINGS + ".kickvehiclefly", kick + "Unexpected vehicle movement.", 1154);
         set(ConfPaths.STRINGS + ".kickwb", kick + "Block breaking out of sync.", 1154);
-        set(ConfPaths.STRINGS + ".kreach", start + "is most likely using a killaura cheat" + end, 1154);
+        set(ConfPaths.STRINGS + ".freachhighvl", start + "is most likely using a killaura cheat" + end, 1154);
         set(ConfPaths.STRINGS + ".morepackets", start + "sent too many moves (&cPackets&7/&cVL [packets]&7)", 1154);
         set(ConfPaths.STRINGS + ".msgtempdenylogin", "You are temporarily denied to join this server.", 785);
         set(ConfPaths.STRINGS + ".munchhausen", start + "tried to hit themeselves with a fishing rod too many times (the knockback can be potentially abused for bypasses)" + end, 1154);
@@ -756,8 +747,8 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.STRINGS + ".clearcf", clear + "MOVING_CREATIVEFLY", 1154);
         set(ConfPaths.STRINGS + ".clearpassable", clear + "MOVING_PASSABLE", 1154);
         set(ConfPaths.STRINGS + ".clearvehicle", clear + "MOVING_VEHICLE_ENVELOPE", 1154);
-        set(ConfPaths.STRINGS + ".clearcritical", clear + "FIGHT_CRITICAL", 1154);
         set(ConfPaths.STRINGS + ".clearscaffold", clear + "BLOCKPLACE_SCAFFOLD", 1154);
+
 
         // Compatibility settings.
         set(ConfPaths.COMPATIBILITY_EXEMPTIONS_WILDCARD_DEFAULT_METADATA_ACTIVE, true, 785);
@@ -780,7 +771,7 @@ public class DefaultConfig extends ConfigFile {
                 )) {
             set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + name, "default+ign_passable+ground_height", 785);
         }
-        // TODO: proper model for these blocks
+        // TODO: Review these block models
         for (final String DeadCoralType : Arrays.asList(
                 "DEAD_TUBE",
                 "DEAD_BRAIN",


### PR DESCRIPTION
Relevant:
+Added kick for the Scaffold check
+Reviewed fight actions for F.Direction and Critical, since they are more reliable now.
+Added kick action for the Critical check
+Add dried kelp to FastConsume exemption list only from 1.13+ (Fix for 1.12 and lower versions)
(+Random changes and formatting)