### PR TITLE
Add dynamic version and include "Updated" to differentiate the fork

### DIFF
--- a/NCPPlugin/src/main/resources/plugin.yml
+++ b/NCPPlugin/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ${project.name}
-version: ${project.version}-b1153-CustomFork
+version: ${project.version}-Updated-${buildDescription}
 description: ${project.description}
 
 author: NeatMonster

--- a/NoCheatPlus/pom.xml
+++ b/NoCheatPlus/pom.xml
@@ -31,6 +31,32 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+	<!-- Build Description Profiles -->
+	<profiles>
+		<profile>
+			<id>timestamp</id>
+			<activation>
+				<property>
+					<name>!env.BUILD_NUMBER</name>
+				</property>
+			</activation>
+			<properties>
+				<buildDescription>${maven.build.timestamp}</buildDescription>
+			</properties>
+		</profile>
+		<profile>
+			<id>dynamic_build_number</id>
+			<activation>
+				<property>
+					<name>env.BUILD_NUMBER</name>
+				</property>
+			</activation>
+			<properties>
+				<buildDescription>b${env.BUILD_NUMBER}</buildDescription>
+			</properties>
+		</profile>
+	</profiles>
+
 	<!-- Building -->
 	<build>
 		<defaultGoal>clean package</defaultGoal>


### PR DESCRIPTION
This includes the real build number in the plugin version if built on Jenkins and the timestamp when locally build. It also adds the "Updated" into the version string to differentiate from the original one.

All of this will help with people reporting issues as the plugin version will actually be helpful, currently that stays the same with each build making it impossible to tell just from the report/log if the reporter didn't think about including that manually.