### PR TITLE
noSlow option in survivalfly

### DIFF
--- a/NCP Config/Auto-Ban/config.yml
+++ b/NCP Config/Auto-Ban/config.yml
@@ -477,6 +477,7 @@ checks:
       extended:
         vertical-accounting: true
       stepheight: default
+      noslow: true
       hbufmax: 1.0
       setbackpolicy:
         falldamage: true

--- a/NCP Config/Auto-Kick/config.yml
+++ b/NCP Config/Auto-Kick/config.yml
@@ -477,6 +477,7 @@ checks:
       extended:
         vertical-accounting: true
       stepheight: default
+      noslow: true
       hbufmax: 1.0
       setbackpolicy:
         falldamage: true

--- a/NCP Config/Notify Only/config.yml
+++ b/NCP Config/Notify Only/config.yml
@@ -480,6 +480,7 @@ checks:
       extended:
         vertical-accounting: true
       stepheight: default
+      noslow: true
       hbufmax: 1.0
       setbackpolicy:
         falldamage: true

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
@@ -141,6 +141,8 @@ public class MovingConfig extends ACheckConfig {
     public final boolean    sfHoverFallDamage;
     public final double		sfHoverViolation;
 
+    public final boolean    sfCheckNoSlow;
+
     // Special tolerance values:
     /**
      * Number of moving packets until which a velocity entry must be activated,
@@ -268,15 +270,17 @@ public class MovingConfig extends ACheckConfig {
         sfSetBackPolicyFallDamage = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE);
         sfSetBackPolicyVoid = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_VOIDTOVOID);
         final double sfStepHeight = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_STEPHEIGHT, Double.MAX_VALUE);
+        sfCheckNoSlow = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_CHECKNOSLOW, true);
+
         if (sfStepHeight == Double.MAX_VALUE) {
             final String ref;
-            if (Bukkit.getVersion().toLowerCase().indexOf("spigot") != -1) {
+            if (Bukkit.getVersion().toLowerCase().contains("spigot")) {
                 // Assume 1.8 clients being supported.
                 ref = "1.7.10";
             } else {
                 ref = "1.8";
             }
-            this.sfStepHeight = ServerVersion.select(ref, 0.5, 0.6, 0.6, 0.5).doubleValue();
+            this.sfStepHeight = ServerVersion.select(ref, 0.5, 0.6, 0.6, 0.5);
         } else {
             this.sfStepHeight = sfStepHeight;
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -1249,7 +1249,7 @@ public class SurvivalFly extends Check {
         // TODO: Attribute modifiers can count in here, e.g. +0.5 (+ 50% doesn't seem to pose a problem, neither speed effect 2).
         else if (!sfDirty && thisMove.from.onGround && actuallySneaking 
                 && (!checkPermissions || !pData.hasPermission(Permissions.MOVING_SURVIVALFLY_SNEAKING, player))
-                ) {
+                && cc.sfCheckNoSlow) {
             tags.add("sneaking");
             hAllowedDistance = Magic.modSneak * thisMove.walkSpeed * cc.survivalFlySneakingSpeed / 100D;
             useBaseModifiers = true;
@@ -1268,7 +1268,7 @@ public class SurvivalFly extends Check {
         else if (!sfDirty && (data.isusingitem || player.isBlocking()) 
                 && (thisMove.from.onGround || data.noslowhop > 0 || player.isBlocking())
                 && (!checkPermissions || !pData.hasPermission(Permissions.MOVING_SURVIVALFLY_BLOCKING, player)) 
-                && data.liftOffEnvelope == LiftOffEnvelope.NORMAL) {
+                && data.liftOffEnvelope == LiftOffEnvelope.NORMAL && cc.sfCheckNoSlow) {
             tags.add("usingitem");
             if (thisMove.from.onGround) {
                 // Jump/left ground

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -695,6 +695,7 @@ public abstract class ConfPaths {
     public static final String MOVING_SURVIVALFLY_SLOWNESSSPRINTHACK        = MOVING_SURVIVALFLY + "slownesssprinthack";
     public static final String MOVING_SURVIVALFLY_GROUNDHOP                 = MOVING_SURVIVALFLY + "groundhop";
     public static final String MOVING_SURVIVALFLY_STEPHEIGHT                = MOVING_SURVIVALFLY + "stepheight";
+    public static final String MOVING_SURVIVALFLY_CHECKNOSLOW               = MOVING_SURVIVALFLY + "noslow";
     private static final String MOVING_SURVIVALFLY_EXTENDED                 = MOVING_SURVIVALFLY + "extended.";
     public static final String MOVING_SURVIVALFLY_EXTENDED_HACC             = MOVING_SURVIVALFLY_EXTENDED + "horizontal-accounting";
     public static final String MOVING_SURVIVALFLY_EXTENDED_VACC             = MOVING_SURVIVALFLY_EXTENDED + "vertical-accounting";


### PR DESCRIPTION
I just realized that the commits message is really misleading but whatever

The reason why i wanted to add this: On some anarchy servers people may want to disable the noslow check since it can slow things down etc people just complain about it a lot.

I'm not sure if a added it to the config correctly but it works for me.