### PR TITLE
Don't drop items in MoreInventory

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
@@ -764,16 +764,7 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
         final Inventory inv = player.getOpenInventory().getTopInventory();
         if (moreInv.isEnabled(player, pData) 
             && moreInv.check(player, data, pData, inv.getType(), inv, PoYdiff)) {
-            // Just simply close inventory ?
-            for (int i =1; i<=4 ;i++) {
-                final ItemStack item = inv.getItem(i);
-                if (item != null && item.getType() != Material.AIR) {
-                    player.getWorld().dropItemNaturally(player.getLocation(), item);
-                    inv.setItem(i, null);
-                    if (pData.isDebugActive(CheckType.INVENTORY_MOREINVENTORY))
-                        debug(player , "Drop items from crafting slot:" + i);
-                }
-            }
+            player.closeInventory();
         }
         // TODO: Let's check for certain conditions here, to see if the player is
         // Actually moving and not just moving from other events (Ice, falling, velocity)


### PR DESCRIPTION
Let Bukkit handle that instead. By closing the player's inventory, we can make sure the drop events are fired in case other plugins want to cancel them. If they do, the items are simply added back to the main inventory.

In the current state, if a plugin wants to make sure no items are dropped, if the player uses a MoreInventory cheat (simply don't send close window packets from the client) to place items in the crafting slots, those items are dropped when the player closes their inventory, because `dropItemNaturally` does not fire any events.