### PR TITLE
Fix FastClick NPE

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastClick.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastClick.java
@@ -166,7 +166,8 @@ public class FastClick extends Check {
         if (InventoryUtil.hasOpenedContainerRecently(player, cc.chestOpenLimit)) {
             // Interaction was too quick, violation.
             tags.add("interact_time");
-            double violation = (cc.chestOpenLimit / (data.lastClickTime - data.containerOpenTime)) * 100D; // Normalize.
+            long duration = Math.max(data.lastClickTime - data.containerOpenTime, 20);
+            double violation = (cc.chestOpenLimit / duration) * 100D; // Normalize.
             data.fastClickVL += violation;
             final ViolationData vd = new ViolationData(this, player, data.fastClickVL, violation, cc.fastClickActions);
             if (vd.needsParameters()) vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));


### PR DESCRIPTION
```
SEVERE: [NoCheatPlus] Exception:
java.lang.reflect.InvocationTargetException
    jdk.internal.reflect.GeneratedMethodAccessor103.invoke(Unknown Source)
    java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    java.base/java.lang.reflect.Method.invoke(Unknown Source)
    fr.neatmonster.nocheatplus.event.mini.MultiListenerRegistry$AutoListener.onEvent(MultiListenerRegistry.java:82)
    fr.neatmonster.nocheatplus.event.mini.MiniListenerNode.onEvent(MiniListenerNode.java:157)
    fr.neatmonster.nocheatplus.event.mini.EventRegistryBukkit$4.execute(EventRegistryBukkit.java:124)
    co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:78)
    org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62)
    org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:513)
    net.minecraft.server.v1_12_R1.PlayerConnection.a(PlayerConnection.java:2020)
    net.minecraft.server.v1_12_R1.PacketPlayInWindowClick.a(SourceFile:33)
    net.minecraft.server.v1_12_R1.PacketPlayInWindowClick.a(SourceFile:10)
    net.minecraft.server.v1_12_R1.PlayerConnectionUtils.lambda$0(PlayerConnectionUtils.java:14)
    java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
    java.base/java.util.concurrent.FutureTask.run(Unknown Source)
    net.minecraft.server.v1_12_R1.SystemUtils.a(SourceFile:46)
    net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:846)
    net.minecraft.server.v1_12_R1.DedicatedServer.D(DedicatedServer.java:418)
    net.minecraft.server.v1_12_R1.MinecraftServer.C(MinecraftServer.java:770)
    net.minecraft.server.v1_12_R1.MinecraftServer.run(MinecraftServer.java:662)
    java.base/java.lang.Thread.run(Unknown Source)
caused by:
java.lang.ArithmeticException: / by zero
    fr.neatmonster.nocheatplus.checks.inventory.FastClick.fastClickChest(FastClick.java:169)
    fr.neatmonster.nocheatplus.checks.inventory.InventoryListener.onInventoryClick(InventoryListener.java:298)
    jdk.internal.reflect.GeneratedMethodAccessor103.invoke(Unknown Source)
    java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    java.base/java.lang.reflect.Method.invoke(Unknown Source)
    fr.neatmonster.nocheatplus.event.mini.MultiListenerRegistry$AutoListener.onEvent(MultiListenerRegistry.java:82)
    fr.neatmonster.nocheatplus.event.mini.MiniListenerNode.onEvent(MiniListenerNode.java:157)
    fr.neatmonster.nocheatplus.event.mini.EventRegistryBukkit$4.execute(EventRegistryBukkit.java:124)
    co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:78)
    org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62)
    org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:513)
    net.minecraft.server.v1_12_R1.PlayerConnection.a(PlayerConnection.java:2020)
    net.minecraft.server.v1_12_R1.PacketPlayInWindowClick.a(SourceFile:33)
    net.minecraft.server.v1_12_R1.PacketPlayInWindowClick.a(SourceFile:10)
    net.minecraft.server.v1_12_R1.PlayerConnectionUtils.lambda$0(PlayerConnectionUtils.java:14)
    java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
    java.base/java.util.concurrent.FutureTask.run(Unknown Source)
    net.minecraft.server.v1_12_R1.SystemUtils.a(SourceFile:46)
    net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:846)
    net.minecraft.server.v1_12_R1.DedicatedServer.D(DedicatedServer.java:418)
    net.minecraft.server.v1_12_R1.MinecraftServer.C(MinecraftServer.java:770)
    net.minecraft.server.v1_12_R1.MinecraftServer.run(MinecraftServer.java:662)
    java.base/java.lang.Thread.run(Unknown Source)
```