### PR TITLE
Link updated CNCP repo instead of old site

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Hints
 * Be sure that your Spigot/CraftBukkit and NoCheatPlus versions match together. The latest version of NCP is compatible with a wide range of CraftBukkit/Spigot versions.
 * Don't use tabs in the config.yml file.
 * Use [ProtocolLib](https://www.spigotmc.org/resources/protocollib.1997/) for full efficiency of the fight checks and other. Using a version of ProtocolLib that is supported by NCP is essential, as otherwise some checks will be disabled.
-* For compatibility with other plugins such as mcMMO, citizens and more check out [CompatNoCheatPlus](https://dev.bukkit.org/projects/compatnocheatplus-cncp/).
+* For compatibility with other plugins such as mcMMO, citizens and more check out [CompatNoCheatPlus](https://github.com/Updated-NoCheatPlus/CompatNoCheatPlus).
 
 Links
 ---------


### PR DESCRIPTION
This replaces the old link to the dbo page of CompatNoCheatPlus with a link to the updated GitHub repo.