### PR TITLE
Replace usage of java.util.Random

### DIFF
--- a/NCPCommons/src/test/java/fr/neatmonster/nocheatplus/test/TestCoordMap.java
+++ b/NCPCommons/src/test/java/fr/neatmonster/nocheatplus/test/TestCoordMap.java
@@ -21,8 +21,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
+import java.util.SplittableRandom;
 
 import org.junit.Test;
 
@@ -74,7 +74,7 @@ public class TestCoordMap {
     private final boolean extraTesting = BuildParameters.testLevel > 0;
     private final int suggestedSamples = extraTesting ? 40000 : 1250;
 
-    public int[][] getRandomCoords(int n, int max, Random random) {
+    private static int[][] getRandomCoords(int n, int max, SplittableRandom random) {
         final int [][] coords = new int[n][3];
         for (int i = 0; i < n; i++){
             for (int j = 0; j < 3 ; j++){
@@ -84,7 +84,7 @@ public class TestCoordMap {
         return coords;
     }
 
-    public int[][] getUniqueRandomCoords(int n, int max, Random random) {
+    private static int[][] getUniqueRandomCoords(int n, int max, SplittableRandom random) {
         Set<Pos> present = new HashSet<Pos>();
         int failures = 0;
         final int [][] coords = new int[n][3];
@@ -311,7 +311,7 @@ public class TestCoordMap {
     @Test
     public void testIntegrity() {
 
-        final Random random = new Random(System.nanoTime() - (System.currentTimeMillis() % 2 == 1 ? 37 : 137));
+        final SplittableRandom random = new SplittableRandom();
 
         final int n = suggestedSamples; // Number of coordinates.
         final int max = 800; // Coordinate maximum.
@@ -333,7 +333,7 @@ public class TestCoordMap {
     @Test
     public void testLinkedCoordHashMap() {
 
-        final Random random = new Random(System.nanoTime() - (System.currentTimeMillis() % 2 == 1 ? 37 : 137));
+        final SplittableRandom random = new SplittableRandom();
 
         final int n = suggestedSamples; // Number of coordinates.
         final int max = 800; // Coordinate maximum.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/ActionFactory.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/ActionFactory.java
@@ -23,7 +23,6 @@ import fr.neatmonster.nocheatplus.checks.ViolationData;
 import fr.neatmonster.nocheatplus.logging.StaticLog;
 import fr.neatmonster.nocheatplus.penalties.CancelPenalty;
 import fr.neatmonster.nocheatplus.penalties.PenaltyNode;
-import fr.neatmonster.nocheatplus.utilities.CheckUtils;
 
 /**
  * Helps with creating Actions out of text string definitions.
@@ -63,10 +62,9 @@ public class ActionFactory extends AbstractActionFactory<ViolationData, ActionLi
                         && probability > 0.0) {
                     // TODO: parsing via factory, store implicit penalties there too.
                     return new PenaltyAction<ViolationData, ActionList>(
-                            "imp_" + actionDefinition, new PenaltyNode(
-                                    CheckUtils.getRandom(), // TODO: store earlier once.
-                                    probability / 100.0, 
-                                    CancelPenalty.CANCEL));
+                        "imp_" + actionDefinition, new PenaltyNode(
+                        probability / 100.0,
+                        CancelPenalty.CANCEL));
                 }
             }
             catch (NumberFormatException e) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/types/CancelAction.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/types/CancelAction.java
@@ -33,7 +33,7 @@ public class CancelAction<D extends ActionData, L extends AbstractActionList<D, 
 
     // TODO: Deprecate this (let it extend penalty.CancelAction)?
 
-    private static final PenaltyNode node = new PenaltyNode(null, CancelPenalty.CANCEL);
+    private static final PenaltyNode node = new PenaltyNode(CancelPenalty.CANCEL);
 
     /**
      * Default cancel action.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Captcha.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Captcha.java
@@ -14,7 +14,7 @@
  */
 package fr.neatmonster.nocheatplus.checks.chat;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.entity.Player;
 
@@ -22,7 +22,6 @@ import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.players.DataManager;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
-import fr.neatmonster.nocheatplus.utilities.CheckUtils;
 import fr.neatmonster.nocheatplus.utilities.ColorUtil;
 
 /**
@@ -32,16 +31,8 @@ import fr.neatmonster.nocheatplus.utilities.ColorUtil;
  */
 public class Captcha extends Check implements ICaptcha{
 
-    /** The random number generator. */
-    // MOVE TO generic registry (unique instance).
-    private final Random random;
-
     public Captcha() {
         super(CheckType.CHAT_CAPTCHA);
-        this.random = CheckUtils.getRandom();
-        if (this.random == null) {
-            throw new IllegalStateException("No Random instance registered.");
-        }
     }
 
     @Override
@@ -82,9 +73,10 @@ public class Captcha extends Check implements ICaptcha{
     public void generateCaptcha(ChatConfig cc, ChatData data, boolean reset) {
         if (reset) data.captchTries = 0;
         final char[] chars = new char[cc.captchaLength];
-        for (int i = 0; i < cc.captchaLength; i++)
-            chars[i] = cc.captchaCharacters.charAt(random
-                    .nextInt(cc.captchaCharacters.length()));
+        for (int i = 0; i < cc.captchaLength; i++) {
+            chars[i] = cc.captchaCharacters.charAt(
+                ThreadLocalRandom.current().nextInt(cc.captchaCharacters.length()));
+        }
         data.captchaGenerated = new String(chars);
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/NoFall.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/NoFall.java
@@ -14,7 +14,7 @@
  */
 package fr.neatmonster.nocheatplus.checks.moving.player;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import fr.neatmonster.nocheatplus.components.registry.feature.TickListener;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
@@ -75,7 +75,6 @@ public class NoFall extends Check {
     /** For temporary use: LocUtil.clone before passing deeply, call setWorld(null) after use. */
     private final Location useLoc = new Location(null, 0, 0, 0);
     private final Location useLoc2 = new Location(null, 0, 0, 0);
-    private final Random random = new Random();
 
     private final static boolean ServerIsAtLeast1_12 = ServerVersion.compareMinecraftVersion("1.12") >= 0;
 
@@ -156,7 +155,7 @@ public class NoFall extends Check {
 
         // TODO: Need move data pTo, this location isn't updated
         Block block = player.getLocation(useLoc2).subtract(0.0, 1.0, 0.0).getBlock();
-        if (block.getType() == BridgeMaterial.FARMLAND && fallDist > 0.5 && random.nextFloat() < fallDist - 0.5) {
+        if (block.getType() == BridgeMaterial.FARMLAND && fallDist > 0.5 && ThreadLocalRandom.current().nextFloat() < fallDist - 0.5) {
             final BlockState newState = block.getState();
             newState.setType(Material.DIRT);
             //if (Bridge1_13.hasIsSwimming()) newState.setBlockData(Bukkit.createBlockData(newState.getType()));
@@ -167,7 +166,7 @@ public class NoFall extends Check {
             }
             return;
         }
-        if (Bridge1_13.hasIsSwimming() && block.getType() == Material.TURTLE_EGG && random.nextInt(3) == 0) {
+        if (Bridge1_13.hasIsSwimming() && block.getType() == Material.TURTLE_EGG && ThreadLocalRandom.current().nextInt(3) == 0) {
             final TurtleEgg egg = (TurtleEgg) block.getBlockData();
             final BlockState newState = block.getState();
             if (canChangeBlock(player, block, newState, true, false, false)) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/penalties/PenaltyNode.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/penalties/PenaltyNode.java
@@ -15,7 +15,7 @@
 package fr.neatmonster.nocheatplus.penalties;
 
 import java.util.Collection;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Internal data representation, managing probabilities, and complex decisions
@@ -30,9 +30,6 @@ public class PenaltyNode {
 
     // TODO: Might add a parsing method (recursive).
 
-
-    /** Random instance to use. May be null, in case probability is 1. */
-    private final Random random;
     /** The probability for this node to apply. */
     public final double probability;
     /** Penalty to apply when this node applies. */
@@ -46,26 +43,23 @@ public class PenaltyNode {
 
     /**
      * Convenience: Simple penalty that always applies with no child nodes.
-     * @param random
      * @param penalty
      */
-    public PenaltyNode(Random random, IPenalty<?> penalty) {
-        this(random, 1.0, penalty, null, false);
+    public PenaltyNode(IPenalty<?> penalty) {
+        this(1.0, penalty, null, false);
     }
 
     /**
      * Convenience: Simple penalty with no child nodes.
-     * @param random
      * @param probability
      * @param penalty
      */
-    public PenaltyNode(Random random, double probability, IPenalty<?> penalty) {
-        this(random, probability, penalty, null, false);
+    public PenaltyNode(double probability, IPenalty<?> penalty) {
+        this(probability, penalty, null, false);
     }
 
     /**
      * 
-     * @param random
      * @param probability
      * @param penalty
      *            Note that child penalties are still evaluated, if penalty is
@@ -75,9 +69,8 @@ public class PenaltyNode {
      * @param abortOnApply
      *            Evaluating child nodes: abort as soon as a child node applies.
      */
-    public PenaltyNode(Random random, double probability, IPenalty<?> penalty,
+    public PenaltyNode(double probability, IPenalty<?> penalty,
             Collection<PenaltyNode> childNodes, boolean abortOnApply) {
-        this.random = random;
         this.probability = probability;
         this.penalty = penalty;
         this.childNodes = childNodes == null ? new PenaltyNode[0] : childNodes.toArray(new PenaltyNode[childNodes.size()]);
@@ -94,7 +87,7 @@ public class PenaltyNode {
      */
     public final boolean evaluate(final IPenaltyList results) {
         // (Set final to ensure return behavior.)
-        if (probability < 1.0 && random.nextDouble() > probability) {
+        if (probability < 1.0 && ThreadLocalRandom.current().nextDouble() > probability) {
             // This node does not apply
             return false;
         }
@@ -131,7 +124,7 @@ public class PenaltyNode {
      * @param results
      */
     protected void evaluateChildrenFCFS(final IPenaltyList results) {
-        final double ref = random.nextDouble(); // No scale contained yet.
+        final double ref = ThreadLocalRandom.current().nextDouble(); // No scale contained yet.
         double floor = 0.0;
         for (int i = 0 ; i < childNodes.length; i++) {
             final PenaltyNode childNode = childNodes[i];

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/CheckUtils.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/CheckUtils.java
@@ -15,7 +15,6 @@
 package fr.neatmonster.nocheatplus.utilities;
 
 import java.util.Arrays;
-import java.util.Random;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
@@ -175,17 +174,6 @@ public class CheckUtils {
             base += "[" + playerName + "] ";
         }
         return base;
-    }
-
-    /**
-     * Convenience method to get a Random instance from the generic registry
-     * (NoCheatPlusAPI).
-     *
-     * @return the random
-     */
-    // TODO: Move official stuff to some static direct access API.
-    public static Random getRandom() {
-        return NCPAPIProvider.getNoCheatPlusAPI().getGenericInstance(Random.class);
     }
 
 }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestRegistrationOrder.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestRegistrationOrder.java
@@ -23,8 +23,8 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.Test;
 
@@ -65,10 +65,6 @@ public class TestRegistrationOrder {
     public static final IAccessSort<IGetRegistrationOrder> accessIGetRegistrationOrder = new AccessIGetRegistrationOrder();
 
     private static String[] tags = new String[]{null, "foo", "bar", "low", "high", "ledge", "bravo", "bravissimo"};
-
-
-
-    private final Random random = new Random(System.currentTimeMillis() ^ System.nanoTime());
 
     @Test
     public void testRegistrationOrder() {
@@ -257,11 +253,11 @@ public class TestRegistrationOrder {
         }
         else {
             Set<Integer> prios = new LinkedHashSet<Integer>();
-            if (random.nextBoolean()) {
+            if (ThreadLocalRandom.current().nextBoolean()) {
                 prios.add(0);
             }
             while (prios.size() < priorities) {
-                prios.add(random.nextInt(2 * priorities + 1) - priorities);
+                prios.add(ThreadLocalRandom.current().nextInt(2 * priorities + 1) - priorities);
             }
             prioArr = new int[priorities];
             int index = 0;
@@ -284,13 +280,13 @@ public class TestRegistrationOrder {
 
     /**
      * Get one using the default tags, beforeTag and afterTag get set to null, 1 2 or 3 others.
-     * @param priority
+     * @param basePriority
      * @return
      */
     private RegistrationOrder getRegistrationOrder(Integer basePriority) {
-        String tag = tags[random.nextInt(tags.length)];
-        String afterTag = random.nextBoolean() ? null : getTagRegex(random.nextInt(3) + 1);
-        String beforeTag = random.nextBoolean() ? null : getTagRegex(random.nextInt(3) + 1);
+        String tag = tags[ThreadLocalRandom.current().nextInt(tags.length)];
+        String afterTag = ThreadLocalRandom.current().nextBoolean() ? null : getTagRegex(ThreadLocalRandom.current().nextInt(3) + 1);
+        String beforeTag = ThreadLocalRandom.current().nextBoolean() ? null : getTagRegex(ThreadLocalRandom.current().nextInt(3) + 1);
         // StaticLog.logInfo("RegistrationOrder(b " + basePriority + " t " + tag + " bt " + beforeTag + " at " + afterTag +  ")");
         return new RegistrationOrder(basePriority, tag, beforeTag, afterTag);
     }
@@ -302,7 +298,7 @@ public class TestRegistrationOrder {
     private String getTagRegex(int combinations) {
         Set<String> indices = new HashSet<String>();
         while (indices.size() < combinations) {
-            indices.add(tags[1 + random.nextInt(tags.length - 1)]); // Avoid null here.
+            indices.add(tags[1 + ThreadLocalRandom.current().nextInt(tags.length - 1)]); // Avoid null here.
         }
         // Combine tags to a regex (simple).
         return"(" + StringUtil.join(indices, "|") + ")";
@@ -360,8 +356,8 @@ public class TestRegistrationOrder {
     private int[][] getSwapIndices(int upperBound, int n) {
         int[][] out = new int[n][2];
         for (int i = 0; i < n; i++) {
-            out[i][0] = random.nextInt(upperBound);
-            out[i][1] = random.nextInt(upperBound);
+            out[i][0] = ThreadLocalRandom.current().nextInt(upperBound);
+            out[i][1] = ThreadLocalRandom.current().nextInt(upperBound);
         }
         return out;
     }

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -27,7 +27,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 
 import org.bukkit.Bukkit;
@@ -949,7 +948,6 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         registerGenericInstance(new PassengerUtil());
         genericInstanceRegistry.denyChangeExistingRegistration(PassengerUtil.class);
         // (Allow override others.)
-        registerGenericInstance(new Random(System.currentTimeMillis() ^ ((long) this.hashCode() * (long) eventRegistry.hashCode() * (long) logManager.hashCode())));
         addComponent(new BridgeCrossPlugin());
 
         // World data init (basic).

--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestLocationTrace.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestLocationTrace.java
@@ -17,7 +17,7 @@ package fr.neatmonster.nocheatplus.test;
 import static org.junit.Assert.fail;
 
 import java.util.Iterator;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.Test;
 
@@ -28,8 +28,6 @@ import fr.neatmonster.nocheatplus.checks.moving.location.tracking.LocationTrace.
 
 
 public class TestLocationTrace {
-
-    protected static final Random random = new Random(System.nanoTime() + 133345691);
 
     /**
      * +- radius around 0.0.
@@ -47,7 +45,7 @@ public class TestLocationTrace {
      * @return
      */
     public static double rand(double center, double radius) {
-        return center + 2.0 * radius * (random.nextDouble() - 0.5);
+        return center + 2.0 * radius * (ThreadLocalRandom.current().nextDouble() - 0.5);
     }
 
     /**
@@ -57,7 +55,7 @@ public class TestLocationTrace {
      * @return
      */
     public static double randStep(double center, double step) {
-        return center + (random.nextBoolean() ? step : -step);
+        return center + (ThreadLocalRandom.current().nextBoolean() ? step : -step);
     }
 
     // TODO: Test pool as well.

--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestRayTracing.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestRayTracing.java
@@ -16,7 +16,7 @@ package fr.neatmonster.nocheatplus.test;
 
 import static org.junit.Assert.fail;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
@@ -30,8 +30,6 @@ import fr.neatmonster.nocheatplus.utilities.location.TrigUtil;
 public class TestRayTracing {
 
     // TODO: Add a test that fails if going beyond target block coordinate.
-
-    protected static final Random random = new Random(System.nanoTime() + 13391);
 
     protected static double maxFactor = 9.0;
 
@@ -61,7 +59,7 @@ public class TestRayTracing {
     public static double[] randomCoords(double max) {
         double[] res = new double[6];
         for (int i = 0; i < 6 ; i++) {
-            res[i] = (random.nextDouble() * 2.0 - 1.0 ) * max;
+            res[i] = (ThreadLocalRandom.current().nextDouble() * 2.0 - 1.0) * max;
         }
         return res;
     }
@@ -69,7 +67,7 @@ public class TestRayTracing {
     public static double[] randomBlockCoords(int max) {
         double[] res = new double[6];
         for (int i = 0; i < 6 ; i++) {
-            res[i] = random.nextInt(max * 2 + 1) -  max;
+            res[i] = ThreadLocalRandom.current().nextInt(max * 2 + 1) - max;
         }
         return res;
     }


### PR DESCRIPTION
Replace usage of java.util.Random with java.util.concurrent.ThreadLocalRandom, or java.util.SplittableRandom when setting seed is required. This provides better performance and randomness.

Also do not manually generate seed when unnecessary since the Java runtime mixes more bits into the automatically generated one.