### PR TITLE
fix: 1.21.3 new packet data for position

### DIFF
--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/MovingFlying.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/MovingFlying.java
@@ -334,7 +334,8 @@ public class MovingFlying extends BaseAdapter {
 
         final PacketContainer packet = event.getPacket();
         final List<Boolean> booleans = packet.getBooleans().getValues();
-        if (booleans.size() != 3) {
+        if (booleans.size() != 3 && booleans.size() != 4) {
+            // 4: 1.21.3 onwards
             packetMismatch(event);
             return null;
         }


### PR DESCRIPTION
HorizontalCollision was added as a new boolean. This caters for it.

Closes #376 