### PR TITLE
Only print debug chat messages when debugging is enabled (#402)

### DIFF
--- a/NCPCompatProtocolLib/pom.xml
+++ b/NCPCompatProtocolLib/pom.xml
@@ -21,7 +21,7 @@
     <repositories>
         <repository>
             <id>dmulloy2-repo</id>
-            <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
+            <url>https://repo.dmulloy2.net/repository/public/</url>
         </repository>
     </repositories>
 

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/InputsAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/InputsAdapter.java
@@ -28,6 +28,7 @@ import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.reflect.StructureModifier;
 import com.comphenix.protocol.wrappers.AutoWrapper;
 
+import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.checks.moving.MovingData;
 import fr.neatmonster.nocheatplus.checks.moving.model.InputDirection;
 import fr.neatmonster.nocheatplus.checks.moving.model.PlayerMoveData;
@@ -89,7 +90,9 @@ public class InputsAdapter extends BaseAdapter {
         boolean sprint = in.sprint;
         // Finally, set.
         thisMove.input = new InputDirection(Boolean.compare(left, right), Boolean.compare(forward, backward));
-        player.sendMessage("Strafe: " + thisMove.input.getStrafeDir() + " Frwd: " + thisMove.input.getForwardDir());
+        if (pData.isDebugActive(CheckType.MOVING)) {
+            player.sendMessage("Strafe: " + thisMove.input.getStrafeDir() + " Frwd: " + thisMove.input.getForwardDir());
+        }
     }
     
     public static class Input7Bools {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/envelope/workaround/LostGround.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/envelope/workaround/LostGround.java
@@ -20,6 +20,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
+import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
 import fr.neatmonster.nocheatplus.checks.moving.MovingData;
 import fr.neatmonster.nocheatplus.checks.moving.envelope.PhysicsEnvelope;
@@ -29,6 +30,7 @@ import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.compat.MCAccess;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
 import fr.neatmonster.nocheatplus.players.DataManager;
+import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.location.PlayerLocation;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
@@ -263,7 +265,11 @@ public class LostGround {
         thisMove.touchedGround = true;
         thisMove.touchedGroundWorkaround = true;
         tags.add("lostground_" + tag);
-        player.sendMessage("lostground_" + tag);
+
+        final IPlayerData pData = DataManager.getPlayerData(player);
+        if (pData.isDebugActive(CheckType.MOVING_SURVIVALFLY) || pData.isDebugActive(CheckType.MOVING_CREATIVEFLY)) {
+            player.sendMessage("lostground_" + tag);
+        }
         return true;
     }
 


### PR DESCRIPTION
This adds checks to all debug chat messages that I found and also improves some cases in SurvivalFly where the debug state is queried multiple times.

I also adjusted the URL of the ProtocolLib repo to point to the (new?) destination to make it build in a fresh environment again.