### PR TITLE
Support copper tools & 1.21.11 ClientVersion

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BridgeMaterial.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BridgeMaterial.java
@@ -187,6 +187,12 @@ public class BridgeMaterial {
     public static final Material NETHERITE_SHOVEL = getFirst("netherite_shovel");
     public static final Material NETHERITE_SWORD = getFirst("netherite_sword");
 
+    public static final Material COPPER_AXE = getFirst("copper_axe");
+    public static final Material COPPER_HOE = getFirst("copper_hoe");
+    public static final Material COPPER_PICKAXE = getFirst("copper_pickaxe");
+    public static final Material COPPER_SHOVEL = getFirst("copper_shovel");
+    public static final Material COPPER_SWORD = getFirst("copper_sword");
+
     public static final Material GOLDEN_AXE = getFirstNotNull("golden_axe", "gold_axe");
     public static final Material GOLDEN_HOE = getFirstNotNull("golden_hoe", "gold_hoe");
     public static final Material GOLDEN_PICKAXE = getFirstNotNull("golden_pickaxe", "gold_pickaxe");

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/versions/ClientVersion.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/versions/ClientVersion.java
@@ -101,10 +101,11 @@ public enum ClientVersion {
      * 1.21.9 / 1.21.10 have the same protocol version.
      */
     V_1_21_9(773),
+    V_1_21_11(774),
 
 
     LOWER_THAN_KNOWN_VERSIONS(V_1_7_2.protocolID - 1, false),
-    HIGHER_THAN_KNOWN_VERSIONS(V_1_21_9.protocolID + 1, false),
+    HIGHER_THAN_KNOWN_VERSIONS(V_1_21_11.protocolID + 1, false),
     UNKNOWN(-1, false);
 
     private final int protocolID;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
@@ -129,14 +129,16 @@ public class BlockProperties {
         WOOD(1, 2f),
         /** The stone. */
         STONE(2, 4f),
+        /** The copper. */
+        COPPER(3, 5f),
         /** The iron. */
-        IRON(3, 6f),
+        IRON(4, 6f),
         /** The diamond. */
-        DIAMOND(4, 8f),
+        DIAMOND(5, 8f),
         /** The netherite */
-        NETHERITE(5, 9f),
+        NETHERITE(6, 9f),
         /** The gold. */
-        GOLD(6, 12f);
+        GOLD(7, 12f);
 
         /** Index for array. */
         public final int index;
@@ -1408,6 +1410,14 @@ public class BlockProperties {
         tools.put(Material.STONE_AXE, new ToolProps(ToolType.AXE, MaterialBase.STONE));
         tools.put(Material.STONE_HOE, new ToolProps(ToolType.HOE, MaterialBase.STONE));
 
+        if (BridgeMaterial.COPPER_SWORD != null) {
+            tools.put(BridgeMaterial.COPPER_SWORD, new ToolProps(ToolType.SWORD, MaterialBase.COPPER));
+            tools.put(BridgeMaterial.COPPER_SHOVEL, new ToolProps(ToolType.SPADE, MaterialBase.COPPER));
+            tools.put(BridgeMaterial.COPPER_PICKAXE, new ToolProps(ToolType.PICKAXE, MaterialBase.COPPER));
+            tools.put(BridgeMaterial.COPPER_AXE, new ToolProps(ToolType.AXE, MaterialBase.COPPER));
+            tools.put(BridgeMaterial.COPPER_HOE, new ToolProps(ToolType.HOE, MaterialBase.COPPER));
+        }
+
         tools.put(Material.IRON_SWORD, new ToolProps(ToolType.SWORD, MaterialBase.IRON));
         tools.put(BridgeMaterial.IRON_SHOVEL, new ToolProps(ToolType.SPADE, MaterialBase.IRON));
         tools.put(Material.IRON_PICKAXE, new ToolProps(ToolType.PICKAXE, MaterialBase.IRON));
@@ -2557,6 +2567,7 @@ public class BlockProperties {
                 case GOLD:
                 case IRON:
                 case NETHERITE:
+                case COPPER:
                 case STONE:
                 case WOOD:
                     return isValidTool;
@@ -2566,6 +2577,7 @@ public class BlockProperties {
         }
         if (blockMat == MaterialBase.STONE) {
             switch (toolMat) {
+                case COPPER:
                 case DIAMOND:
                 case IRON:
                 case NETHERITE:
@@ -2577,6 +2589,7 @@ public class BlockProperties {
         }
         if (blockMat == MaterialBase.IRON) {
             switch (toolMat) {
+                case COPPER:
                 case DIAMOND:
                 case IRON:
                 case NETHERITE:


### PR DESCRIPTION
This adds support for copper tools (previously using them would just cause the block mining to be cancelled because it would mine too fast).

Also I took the liberty of adding a 1.21.11 constant to the ClientVersion class. I did some basic testing with 1.21.11 and didn't notice anything obvious (spear needs to be separately supported of course, I noticed it causes fight_reach (due to having a reach of 4.5 blocks) as well as fight_noswing failures in the tired charge state (as that doesn't play a separate animation as you do damage on collision with it))