### PR TITLE
Use correct itemInUse method (Fixes #423)

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/BridgeMisc.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/BridgeMisc.java
@@ -198,7 +198,7 @@ public class BridgeMisc {
         }
         // Very old server (1.11 and below), use NCP's adapter.
         final IPlayerData pData = DataManager.getPlayerData(player);
-        return pData.getItemInUse() != null;
+        return pData != null && pData.getItemInUse() != null;
     }
     
     /**
@@ -209,7 +209,7 @@ public class BridgeMisc {
      * @return
      */
     public static boolean isSlowedDownByUsingAnItem(final Player player) {
-        return isUsingItem(player) && !MaterialUtil.isSpear(DataManager.getPlayerData(player).getItemInUse());
+        return isUsingItem(player) && (player.getItemInUse() == null || !MaterialUtil.isSpear(getItemInUse(player)));
         
     }
     
@@ -217,11 +217,21 @@ public class BridgeMisc {
      * Get the Material type of the item the player is currently using.
      *
      * @param player
-     * @return True, if either {@link Player#getItemInUse()} or {@link IPlayerData#getItemInUse()} returns true
+     * @return The material of the item (from {@link Player#getItemInUse()} or {@link IPlayerData#getItemInUse()}) or <code>null</code>
      */
     public static Material getItemInUse(final Player player) {
-    	final IPlayerData pData = DataManager.getPlayerData(player);
-        return hasGetItemInUseMethod() ? player.getItemInUse().getType() : pData.getItemInUse();
+        if (hasGetItemInUseMethod()) {
+            final ItemStack item = player.getItemInUse();
+            if (item != null) {
+                return item.getType();
+            }
+        } else {
+            final IPlayerData pData = DataManager.getPlayerData(player);
+            if (pData != null) {
+                return pData.getItemInUse();
+            }
+        }
+        return null;
     }
     
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/IPlayerData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/IPlayerData.java
@@ -429,6 +429,8 @@ public interface IPlayerData extends IData, IBaseDataAccess, IGetGenericInstance
     
     /**
      * Get the item currently in use, as set by PlayerData#setItemInUse
+     *
+     * Should not be used directly but via {@link fr.neatmonster.nocheatplus.compat.BridgeMisc#getItemInUse(Player)}!
      * 
      * @return The enum Material of the item in use.
      */


### PR DESCRIPTION
This fixes that the right click (charge) functionality of spears leads to false positives and that charging is impossible with the default config. (See #423)

I also adjusted the documentation so the correct BridgeMisc method is mentioned and hopefully such errors are prevented and also adjusted the BridgeMisc code slightly to prevent potential NPE in BridgeMisc#getItemInUse