### PR TITLE
Diagnostics config and documentation

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
@@ -28,6 +28,8 @@ import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.compat.bukkit.BridgePotionEffect;
 import fr.neatmonster.nocheatplus.permissions.Permissions;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.entity.PotionUtil;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
@@ -62,6 +64,11 @@ public class FastBreak extends Check {
                                          // Counting break...break.
                                          : (data.fastBreakBreakTime > now) ? 0 : now - data.fastBreakBreakTime;
 
+        /*
+         * FastBreak compatibility: keep the grace threshold configurable.
+         * The safer modern default belongs in config, while this check only
+         * compares measured block/tool timing against that configured budget.
+         */
         // Check if the time spent is lower than expected.
         if (isInstaBreak.decideOptimistically()) {
             // Ignore these for now.
@@ -80,13 +87,26 @@ public class FastBreak extends Check {
                 // Add as penalty
                 data.fastBreakPenalties.add(now, (float) missingTime);
                 // Only raise a violation, if the total penalty score exceeds the contention duration (for lag, delay).
-                if (data.fastBreakPenalties.score(cc.fastBreakBucketFactor) > cc.fastBreakGrace) {
+                final float penaltyScore = data.fastBreakPenalties.score(cc.fastBreakBucketFactor);
+                if (penaltyScore > cc.fastBreakGrace) {
                     // TODO: maybe add one absolute penalty time for big amounts to stop breaking until then
                     final double violation = (double) missingTime / 1000.0;
                     data.fastBreakVL += violation;
+                    final ItemStack stack = Bridge1_9.getItemInMainHand(player);
+                    final Material toolType = stack == null ? Material.AIR : stack.getType();
+                    final boolean isValidTool = BlockProperties.isValidTool(blockType, stack);
+                    final double haste = PotionUtil.getPotionEffectAmplifier(player, BridgePotionEffect.HASTE);
+                    // Diagnostic info: tag the timing branch so false FastBreak reports show the block/tool context.
+                    final String tags = getFastBreakTags(isInstaBreak, cc, isValidTool, haste, elapsedTime, missingTime);
                     final ViolationData vd = new ViolationData(this, player, data.fastBreakVL, violation, cc.fastBreakActions);
                     if (vd.needsParameters()) {
                         vd.setParameter(ParameterName.BLOCK_TYPE, blockType.toString());
+                        vd.setParameter(ParameterName.TAGS, tags);
+                    }
+                    if (CheckUtils.shouldLogDebugToConsole()) {
+                        logFastBreakDetail(player, blockType, toolType, isInstaBreak, isValidTool, haste,
+                                elapsedTime, expectedBreakingTime, missingTime, serverLagFactor,
+                                penaltyScore, data.fastBreakVL, violation, cc, tags);
                     }
                     cancel = executeActions(vd).willCancel();
                 }
@@ -131,5 +151,70 @@ public class FastBreak extends Check {
             //              player.sendMessage("mc speed: " + x);
             //          }
         }
+    }
+
+    private String getFastBreakTags(final AlmostBoolean isInstaBreak, final BlockBreakConfig cc,
+                                    final boolean isValidTool, final double haste,
+                                    final long elapsedTime, final long missingTime) {
+        // Diagnostic info: these tags describe why the umbrella FastBreak check added VL.
+        final StringBuilder builder = new StringBuilder(120);
+        builder.append("subcheck_fastbreak_timing")
+                .append("+branch_expected_duration")
+                .append(cc.fastBreakStrict ? "+strict_interact_break" : "+break_break")
+                .append("+insta_").append(isInstaBreak.name().toLowerCase())
+                .append(isValidTool ? "+valid_tool" : "+invalid_tool");
+        if (Double.isInfinite(haste)) {
+            builder.append("+no_haste");
+        }
+        else {
+            builder.append("+haste_").append((int) haste + 1);
+        }
+        if (elapsedTime == 0L) {
+            builder.append("+zero_elapsed");
+        }
+        if (missingTime >= 1000L) {
+            builder.append("+large_missing_time");
+        }
+        return builder.toString();
+    }
+
+    private void logFastBreakDetail(final Player player, final Material blockType, final Material toolType,
+                                    final AlmostBoolean isInstaBreak, final boolean isValidTool,
+                                    final double haste, final long elapsedTime,
+                                    final long expectedBreakingTime, final long missingTime,
+                                    final float serverLagFactor, final float penaltyScore,
+                                    final double totalVL, final double addedVL,
+                                    final BlockBreakConfig cc, final String tags) {
+        try {
+            // Diagnostic info: console-only detail for tuning FastBreak grace without changing check behavior.
+            player.getServer().getLogger().info(new StringBuilder(380)
+                    .append("[NCP][FastBreak][detail] player=").append(player.getName())
+                    .append(" uuid=").append(player.getUniqueId())
+                    .append(" subcheck=FASTBREAK_TIMING")
+                    .append(" summary=block_timing{missingMs=").append(missingTime)
+                    .append(",graceMs=").append(StringUtil.fdec3.format(cc.fastBreakGrace))
+                    .append(",tool=").append(isValidTool ? "valid" : "invalid")
+                    .append(",insta=").append(isInstaBreak.name().toLowerCase())
+                    .append('}')
+                    .append(" block=").append(blockType)
+                    .append(" tool=").append(toolType)
+                    .append(" validTool=").append(isValidTool)
+                    .append(" insta=").append(isInstaBreak.name())
+                    .append(" strict=").append(cc.fastBreakStrict)
+                    .append(" elapsedMs=").append(elapsedTime)
+                    .append(" expectedMs=").append(expectedBreakingTime)
+                    .append(" missingMs=").append(missingTime)
+                    .append(" lagFactor=").append(StringUtil.fdec3.format(serverLagFactor))
+                    .append(" penaltyScore=").append(StringUtil.fdec3.format(penaltyScore))
+                    .append(" graceMs=").append(StringUtil.fdec3.format(cc.fastBreakGrace))
+                    .append(" delayMs=").append(cc.fastBreakDelay)
+                    .append(" modSurvival=").append(cc.fastBreakModSurvival)
+                    .append(" haste=").append(Double.isInfinite(haste) ? "none" : Integer.toString((int) haste + 1))
+                    .append(" addVL=").append(StringUtil.fdec3.format(addedVL))
+                    .append(" totalVL=").append(StringUtil.fdec3.format(totalVL))
+                    .append(" tags=").append(tags)
+                    .toString());
+        }
+        catch (Throwable ignored) {}
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -82,6 +82,9 @@ public abstract class ConfPaths {
     private static final String LOGGING                                  = "logging.";
     public static final String  LOGGING_ACTIVE                           = LOGGING + SUB_ACTIVE;
     public static final String  LOGGING_MAXQUEUESIZE                     = LOGGING + "max-queue-size";
+    private static final String LOGGING_DEBUG_SECTION                    = LOGGING + "debug.";
+    /** Toggle for custom verbose diagnostic lines such as [NCP][SurvivalFly][detail]. */
+    public static final String  LOGGING_DEBUG_TO_CONSOLE                 = LOGGING_DEBUG_SECTION + "to-console";
 
     private static final String LOGGING_BACKEND                          = LOGGING + "backend.";
     private static final String LOGGING_BACKEND_CONSOLE                  = LOGGING_BACKEND + "console.";
@@ -629,6 +632,8 @@ public abstract class ConfPaths {
     private static final String MOVING_SURVIVALFLY_EXTENDED                 = MOVING_SURVIVALFLY + "extended.";
     public static final String MOVING_SURVIVALFLY_EXTENDED_RESETITEM        = MOVING_SURVIVALFLY_EXTENDED + "reset-activeitem";
     public static final String MOVING_SURVIVALFLY_EXTENDED_STRICT_HORIZONTAL_PREDICTION = MOVING_SURVIVALFLY_EXTENDED + "strict-speed-prediction";
+    private static final String MOVING_SURVIVALFLY_ELYTRA                   = MOVING_SURVIVALFLY + "elytra.";
+    public static final String MOVING_SURVIVALFLY_ELYTRA_ENFORCE            = MOVING_SURVIVALFLY_ELYTRA + "enforce";
     private static final String MOVING_SURVIVALFLY_LENIENCY                 = MOVING_SURVIVALFLY + "leniency.";
     public static final String MOVING_SURVIVALFLY_LENIENCY_FREEZECOUNT      = MOVING_SURVIVALFLY_LENIENCY + "freeze-count";
     public static final String MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR      = MOVING_SURVIVALFLY_LENIENCY + "freeze-inair";
@@ -646,6 +651,7 @@ public abstract class ConfPaths {
     @GlobalConfig
     public static final String  MOVING_SURVIVALFLY_HOVER                    = MOVING_SURVIVALFLY + "hover.";
     public static final String  MOVING_SURVIVALFLY_HOVER_CHECK              = MOVING_SURVIVALFLY_HOVER + SUB_ACTIVE;
+    public static final String  MOVING_SURVIVALFLY_HOVER_ELYTRA_ENFORCE     = MOVING_SURVIVALFLY_HOVER + "elytra-enforce";
     public static final String  MOVING_SURVIVALFLY_HOVER_STEP               = MOVING_SURVIVALFLY_HOVER + "step";
     public static final String  MOVING_SURVIVALFLY_HOVER_TICKS              = MOVING_SURVIVALFLY_HOVER + "ticks";
     public static final String  MOVING_SURVIVALFLY_HOVER_LOGINTICKS         = MOVING_SURVIVALFLY_HOVER + "login-ticks";

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -50,13 +50,16 @@ public class DefaultConfig extends ConfigFile {
         //        not set(ConfPaths.CONFIGVERSION_SAVED, -1);
         set(ConfPaths.LOGGING_ACTIVE, true, 154);
         set(ConfPaths.LOGGING_MAXQUEUESIZE, 5000, 154);
+        // Compatibility diagnostics are opt-in because the extra movement/Folia details are too noisy for normal servers.
+        set(ConfPaths.LOGGING_DEBUG_TO_CONSOLE, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_STATUS, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_COMMANDS_ACTIONS, false, 1090);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_DEBUG, true, 154);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_DEBUGONLY, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_TRACE, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_NOTIFY, false, 154);
-        set(ConfPaths.LOGGING_BACKEND_CONSOLE_ACTIVE, true, 154);
+        // Default console backend off: server owners can opt in to console logging when debugging false positives.
+        set(ConfPaths.LOGGING_BACKEND_CONSOLE_ACTIVE, false, 154);
         set(ConfPaths.LOGGING_BACKEND_CONSOLE_ASYNCHRONOUS, true, 154);
         set(ConfPaths.LOGGING_BACKEND_FILE_ACTIVE, true, 154);
         set(ConfPaths.LOGGING_BACKEND_FILE_PREFIX, "", 154);
@@ -121,7 +124,8 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.BLOCKBREAK_FASTBREAK_STRICT, true, 154);
         set(ConfPaths.BLOCKBREAK_FASTBREAK_DELAY, 10, 154); 
         set(ConfPaths.BLOCKBREAK_FASTBREAK_MOD_SURVIVAL, 100, 154);
-        set(ConfPaths.BLOCKBREAK_FASTBREAK_GRACE, 500, 154);
+        // False-positive tuning: modern/Folia block-dig timing can need a larger grace, but keep it configurable.
+        set(ConfPaths.BLOCKBREAK_FASTBREAK_GRACE, 2000, 154);
         set(ConfPaths.BLOCKBREAK_FASTBREAK_ACTIONS, "cancel vl>5 cancel log:fastbreak:4:2:i vl>50 cancel log:fastbreak:0:2:if cmdc:kickfastbreak:2:5", 154);
         // Frequency
         set(ConfPaths.BLOCKBREAK_FREQUENCY_CHECK, "default", 154);
@@ -479,6 +483,8 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_SURVIVALFLY_STEPHEIGHT, "default", 154);
         set(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_RESETITEM, true, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_STRICT_HORIZONTAL_PREDICTION, true, 154);
+        // Elytra model collection: keep false while tuning from flightTrace/detail logs to avoid setback deaths.
+        set(ConfPaths.MOVING_SURVIVALFLY_ELYTRA_ENFORCE, false, 154);
         // SurvivalFly - ViolationFrequencyHook
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_ACTIVE, true, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_DEBUG, false, 154);
@@ -496,6 +502,8 @@ public class DefaultConfig extends ConfigFile {
             + " vl>2100 cancel log:survivalflyhighvl:0:4:icf cmdc:kickfly:0:15", 154);     
         // SurvivalFly - Hover Subcheck
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_CHECK, true, 154); // Not a check type yet.
+        // Elytra hover model telemetry stays data-only by default until server owners opt into enforcement.
+        set(ConfPaths.MOVING_SURVIVALFLY_HOVER_ELYTRA_ENFORCE, false, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_STEP, 5, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_TICKS, 85, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_LOGINTICKS, 60, 154);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/Permissions.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/Permissions.java
@@ -58,6 +58,7 @@ public class Permissions {
 
     // Notifications (in-game).
     public static final RegisteredPermission  NOTIFY                       = add(NOCHEATPLUS + ".notify");
+    public static final RegisteredPermission  COMPAT_BEDROCK              = add(NOCHEATPLUS + ".compat.bedrock");
 
     // Command permissions.
     public static final RegisteredPermission  COMMAND                      = add(NOCHEATPLUS + ".command");

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/CheckUtils.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/CheckUtils.java
@@ -28,6 +28,8 @@ import fr.neatmonster.nocheatplus.checks.fight.FightData;
 import fr.neatmonster.nocheatplus.checks.inventory.InventoryData;
 import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
 import fr.neatmonster.nocheatplus.components.concurrent.IPrimaryThreadContextTester;
+import fr.neatmonster.nocheatplus.config.ConfigManager;
+import fr.neatmonster.nocheatplus.config.ConfPaths;
 import fr.neatmonster.nocheatplus.logging.StaticLog;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
@@ -76,6 +78,11 @@ public class CheckUtils {
             improperAsynchronousAPIAccess(checkType);
             return false;
         }
+    }
+
+    public static boolean shouldLogDebugToConsole() {
+        // This gates the extra diagnostic console spam added for compatibility tuning, not the normal NCP backend loggers.
+        return ConfigManager.getConfigFile().getBoolean(ConfPaths.LOGGING_DEBUG_TO_CONSOLE, false);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Links
 ###### Support and Documentation
 * [Issues/Tickets](https://github.com/Updated-NoCheatPlus/NoCheatPlus/issues)
 * [Wiki](https://github.com/Updated-NoCheatPlus/Docs)
+* [Compatibility debugging guide](docs/compat-debugging.md)
 * [Configuration](https://github.com/Updated-NoCheatPlus/Docs#configuration)
 * [Permissions](https://github.com/Updated-NoCheatPlus/Docs/blob/master/Settings/Permissions.md)
 * [Commands](https://github.com/Updated-NoCheatPlus/Docs/blob/master/Settings/Commands.md)

--- a/docs/compat-debugging.md
+++ b/docs/compat-debugging.md
@@ -1,0 +1,151 @@
+# Compatibility Debugging Guide
+
+This guide explains the extra compatibility diagnostics added for Bedrock, Folia, modern movement clients, and false-positive tuning. The goal is to make console logs easier to read without losing the detailed values needed to refine checks.
+
+## Enabling Console Detail
+
+The detailed compatibility lines are opt-in because they can be noisy on live servers. Enable them only while testing or collecting false-positive reports.
+
+Relevant config paths:
+
+```yaml
+logging:
+  debug:
+    to-console: true
+  backend:
+    console:
+      active: true
+```
+
+The normal violation/debug settings still control whether a check has enough debug context to print.
+
+## Reading A Detail Line
+
+Most new detail lines keep the same shape:
+
+```text
+[NCP][CheckName][detail] player=name subcheck=SPECIFIC_BRANCH summary=short_reason{...} ... tags=...
+```
+
+Important fields:
+
+| Field | Meaning |
+| --- | --- |
+| `subcheck` | The concrete branch behind the umbrella check name. Use this first when sorting logs. |
+| `summary` | Short human-readable diagnosis for quick scanning. This is intentionally near the front of the line. |
+| `movementMode` | SurvivalFly movement state such as `GROUND`, `WATER`, `CLIMBABLE`, `ELYTRA_GLIDING`, or `ELYTRA_FIREWORK`. |
+| `model` | The selected SurvivalFly model branch, if one matched the movement context. |
+| `hOver` | Remaining horizontal distance over the model boundary after model handling. |
+| `yOver` | Remaining vertical distance over the model boundary after model handling. |
+| `physicsModel` | Diagnostic-only gravity/velocity probe for SurvivalFly. It shows expected next fall speed, actual acceleration, server velocity differences, and horizontal-vs-vertical glide ratios. |
+| `tags` | Full diagnostic markers for deeper analysis. |
+
+## SurvivalFly Tags
+
+SurvivalFly logs are the densest because one umbrella check covers many movement states.
+
+Common tag groups:
+
+| Tag prefix | Meaning |
+| --- | --- |
+| `subcheck_` | Final readable failure type, for example `subcheck_elytra_firework_y`. |
+| `mode_` | Broad movement mode at the time of the violation. |
+| `branch_` | Important branch/context that influenced diagnosis, such as liquid, collision, velocity, or recent setback. |
+| `branch_model_` | The code selected a named movement model for this move. |
+| `model_*` | A selected model accepted part of the movement. Suffix `_h` means horizontal, `_y` means vertical. |
+| `model_*_miss` | A model was selected but did not accept the movement envelope. This is usually the next place to refine. |
+| `diag_*` | Diagnostic probe only. It marks a likely area to inspect but does not mean movement was accepted. |
+
+Example:
+
+```text
+summary=elytra_firework_y{mode=elytra_firework,model=elytra_firework,axis=y,hOver=0,yOver=0.035,tags=subcheck_elytra_firework_y+branch_elytra_state+branch_model_elytra_firework}
+```
+
+Practical reading:
+
+- The player was actively gliding with a firework.
+- The selected model was `elytra_firework`.
+- The remaining miss was vertical (`axis=y`).
+- `yOver=0.035` is the amount still outside the accepted model.
+- If this was false, refine the elytra firework vertical model, not generic SurvivalFly.
+
+## Teleport And Portal Sync
+
+Folia and modern teleport plugins can use `teleportAsync`, portal callbacks, or direct server position packets. In those cases, packet-level `NET_MOVING` may see the position jump before SurvivalFly has clean movement history for the new location.
+
+Useful tags:
+
+| Tag | Meaning |
+| --- | --- |
+| `server_position_jump_stale_packet_model` | `NET_MOVING` matched a stale pre-teleport packet to a recent server-side position jump. This is not elytra-specific. |
+| `teleport_command_stale_packet_model` | A command such as `/home` or `/rtp` was recently issued, and the old packet still fit the command-location stale-packet model. |
+| `server_position_jump_recovery_grace` | One last-resort stale packet was consumed after a server-side jump when movement history was invalid. |
+| `server_position_jump_air_resync_horizontal_model` | SurvivalFly accepted a small post-teleport air/fall horizontal mismatch using the server-position resync model. |
+| `server_position_jump_air_resync_vertical_model` | SurvivalFly accepted the next post-teleport vertical packet as a vanilla gravity continuation. |
+
+The final teleport sync model handles the common Folia/ProtocolLib packet order pattern where one or two old-location packets arrive after a command teleport, `/rtp`, `/spawn`, `/home`, respawn, or portal-style server-position jump. Those packets are deleted from packet history and do not represent player movement at the new location. Console diagnostics are intentionally quiet for that normal one-or-two-packet pattern; repeated stale packets beyond that still log so the packet ordering model can be refined.
+
+If teleport false positives remain, include the `NET_MOVING` detail, the matching `NET_MOVING][teleport]` line, and the next SurvivalFly detail line. The useful fields are `serverJumpAge`, `serverJumpFrom`, `serverJumpTo`, `serverJumpStalePacketModel`, `commandStalePacketModel`, `packetModel`, `movementMode`, `movementModel`, `modelProbe`, `summary`, and `tags`.
+
+## Folia Block Cache Fallback
+
+Folia region ownership can make direct block reads unsafe from packet or async paths. The Bukkit block cache now first checks normal region ownership, then retries with exact-location ownership before returning `AIR` or legacy data `0` as the final safe fallback.
+
+Single fallback events during teleport or chunk handoff are expected and are not printed to console. Repeated fallback events are rate-limited and logged as safe fallback diagnostics with resolved and final-fallback counts.
+
+## Other Check Summaries
+
+The other detailed checks now include short `summary` fields too:
+
+| Check | Summary shape | What it helps identify |
+| --- | --- | --- |
+| FastBreak | `summary=block_timing{...}` | Block/tool timing, missing break time, grace budget. |
+| FightAngle | `summary=angle_*{...}` | Aim angle, timing, movement, or target-switch branch. |
+| FightCritical | `summary=critical_*{...}` | Fall-distance mismatch, reset-condition criticals, jump-phase desync. |
+| BlockDirection | `summary=block_direction{...}` | Ray miss vs unreachable block face. |
+| MorePackets | `summary=packet_rate{...}` | Packet-rate or burst violations separate from movement model errors. |
+| Passable | `summary=passable_raytrace{...}` | Ray-trace branch and block types involved in stuck/inside-block flags. |
+| KeepAliveFrequency | `summary=keepalive_bucket{...}` | Bucket timing, duplicate/fast keep-alive replies, Folia async timing. |
+| NetMoving | `summary=net_moving{...}` | Extreme packet movement vs teleport/server-position stale-packet models. |
+
+## What To Include In A Bug Report
+
+When reporting a false positive, include:
+
+1. The full `[NCP][...][detail]` line, not only the short `[NC+] [VL]` line.
+2. What the player was doing in plain terms, such as "Bedrock player running up stairs" or "elytra firework into ground".
+3. Whether the player was Bedrock or Java.
+4. The block or environment involved, especially stairs, slabs, lanterns, carpet, vines, scaffolding, water, boats, or portals.
+5. A few lines before and after the flag if teleport, respawn, knockback, firework, or combat happened.
+
+For SurvivalFly false positives, the most useful first fields are:
+
+```text
+summary=...
+movementMode=...
+subcheck=...
+movementModel=...
+physicsModel=...
+modelProbe=...
+elytraModel=...
+tags=...
+```
+
+## Model vs Grace
+
+Some constants still contain `GRACE` in their names for history. In the newer model paths, those values should be treated as empirical residual boundaries inside a selected movement state.
+
+Preferred design:
+
+```text
+identify movement state -> select model -> calculate boundary -> compare actual movement
+```
+
+Avoid this design when changing future code:
+
+```text
+normal model fails -> broad grace accepts actual movement afterward
+```
+
+If a tolerance remains because packet ordering, Folia timing, teleport sync, or floating-point precision cannot be modeled exactly, document that reason next to the code.


### PR DESCRIPTION
## Summary

Adds configuration and documentation for the compatibility/debugging work so server owners can control verbose diagnostic output while testing Folia, Bedrock, and movement false positives.

## What Changed

- Adds a `logging.debug.to-console` config option.
- Sets extra diagnostic console output to be disabled by default.
- Adds a shared `CheckUtils.shouldLogDebugToConsole()` helper for gating compatibility debug logs.
- Moves the FastBreak safer modern default into config instead of forcing it as a hardcoded minimum.
- Adds compatibility debugging documentation in `docs/compat-debugging.md`.
- Adds README/docs references for the new debugging notes.

## Why

The larger compatibility work needs detailed logs during testing, but that output should not spam production servers unless explicitly enabled. This PR makes the diagnostics opt-in and documents how to use them.

## Notes

This PR is the first branch in the stacked series. Later PRs add the Folia/net sync fixes, block/environment compatibility foundations, Bedrock movement handling, and SurvivalFly/elytra model changes.
