### PR TITLE
Bedrock general movement

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkit.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkit.java
@@ -14,6 +14,10 @@
  */
 package fr.neatmonster.nocheatplus.compat.bukkit;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -21,12 +25,20 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 
 import fr.neatmonster.nocheatplus.compat.Bridge1_13;
+import fr.neatmonster.nocheatplus.compat.SchedulerHelper;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
 import fr.neatmonster.nocheatplus.utilities.map.BlockFlags;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
 import fr.neatmonster.nocheatplus.utilities.map.MaterialUtil;
 
 public class BlockCacheBukkit extends BlockCache {
+
+    private static final long FOLIA_FALLBACK_LOG_INTERVAL_MS = 10000L;
+    private static final int FOLIA_FALLBACK_CONSOLE_LOG_MIN_COUNT = 2;
+    private static final AtomicInteger foliaFallbackCount = new AtomicInteger();
+    private static final AtomicInteger foliaFallbackResolvedCount = new AtomicInteger();
+    private static final AtomicLong nextFoliaFallbackLog = new AtomicLong();
 
     protected World world;
 
@@ -50,14 +62,90 @@ public class BlockCacheBukkit extends BlockCache {
     @Override
     public Material fetchTypeId(final int x, final int y, final int z) {
         // TODO: consider setting type id and data at once.
-        return world.getBlockAt(x, y, z).getType();
+        if (world == null) {
+            return Material.AIR;
+        }
+        if (SchedulerHelper.isOwnedByCurrentRegion(world, x, z)) {
+            return world.getBlockAt(x, y, z).getType();
+        }
+        final Material fallbackType = fetchTypeIdWithLocationFallback(x, y, z);
+        return fallbackType == null ? Material.AIR : fallbackType;
     }
 
     @SuppressWarnings("deprecation")
     @Override
     public int fetchData(final int x, final int y, final int z) {
         // TODO: consider setting type id and data at once.
-        return Bridge1_13.hasIsSwimming() ? 0 : world.getBlockAt(x, y, z).getData();
+        if (world == null) {
+            return 0;
+        }
+        if (SchedulerHelper.isOwnedByCurrentRegion(world, x, z)) {
+            return Bridge1_13.hasIsSwimming() ? 0 : world.getBlockAt(x, y, z).getData();
+        }
+        final Integer fallbackData = fetchDataWithLocationFallback(x, y, z);
+        return fallbackData == null ? 0 : fallbackData.intValue();
+    }
+
+    private Material fetchTypeIdWithLocationFallback(final int x, final int y, final int z) {
+        // Folia compatibility: if the chunk-level ownership check cannot prove safety, retry the exact location.
+        // If that also fails, keep AIR as the safe final fallback instead of touching another region's block state.
+        boolean resolved = false;
+        try {
+            if (SchedulerHelper.isOwnedByCurrentRegion(new Location(world, x, y, z))) {
+                resolved = true;
+                return world.getBlockAt(x, y, z).getType();
+            }
+        }
+        catch (Throwable t) {
+            // Keep the final AIR fallback for servers that throw while checking ownership or block state.
+        }
+        finally {
+            logFoliaBlockFallback("type", resolved);
+        }
+        return null;
+    }
+
+    @SuppressWarnings("deprecation")
+    private Integer fetchDataWithLocationFallback(final int x, final int y, final int z) {
+        // Folia compatibility: retry exact-location ownership before returning legacy data 0 as the final fallback.
+        boolean resolved = false;
+        try {
+            if (SchedulerHelper.isOwnedByCurrentRegion(new Location(world, x, y, z))) {
+                resolved = true;
+                return Integer.valueOf(Bridge1_13.hasIsSwimming() ? 0 : world.getBlockAt(x, y, z).getData());
+            }
+        }
+        catch (Throwable t) {
+            // Keep the final data 0 fallback for servers that throw while checking ownership or block state.
+        }
+        finally {
+            logFoliaBlockFallback("data", resolved);
+        }
+        return null;
+    }
+
+    private static void logFoliaBlockFallback(final String kind, final boolean resolved) {
+        if (!CheckUtils.shouldLogDebugToConsole()) {
+            return;
+        }
+        final int count = foliaFallbackCount.incrementAndGet();
+        if (resolved) {
+            foliaFallbackResolvedCount.incrementAndGet();
+        }
+        final long now = System.currentTimeMillis();
+        final long next = nextFoliaFallbackLog.get();
+        if (now < next || !nextFoliaFallbackLog.compareAndSet(next, now + FOLIA_FALLBACK_LOG_INTERVAL_MS)) {
+            return;
+        }
+        final int resolvedCount = foliaFallbackResolvedCount.getAndSet(0);
+        final int periodCount = foliaFallbackCount.getAndSet(0);
+        // Folia diagnostic: a single safe fallback during teleport/chunk handoff is expected and not useful console noise.
+        if (periodCount < FOLIA_FALLBACK_CONSOLE_LOG_MIN_COUNT) {
+            return;
+        }
+        Bukkit.getLogger().info("[NCP][Folia][BlockCache] safe " + kind + " block fallback used "
+                                + periodCount + " times in the last 10s, resolved=" + resolvedCount
+                                + ", finalSafeFallback=" + (periodCount - resolvedCount) + ".");
     }
 
     @Override
@@ -74,11 +162,17 @@ public class BlockCacheBukkit extends BlockCache {
 
     @Override
     public boolean standsOnEntity(final Entity entity, final double minX, final double minY, final double minZ, final double maxX, final double maxY, final double maxZ){
+        if (!SchedulerHelper.isOwnedByCurrentRegion(entity)) {
+            return false;
+        }
         try{
             // TODO: Probably check other ids too before doing this ?
             for (final Entity other : entity.getNearbyEntities(2.0, 2.0, 2.0)){
+                if (!SchedulerHelper.isOwnedByCurrentRegion(other)) {
+                    continue;
+                }
                 final EntityType type = other.getType();
-                if (!MaterialUtil.isBoat(type) && type != EntityType.SHULKER){ //  && !(other instanceof Minecart)) 
+                if (!MaterialUtil.isBoat(type) && type != EntityType.SHULKER){ //  && !(other instanceof Minecart))
                     continue;
                 }
                 final double locY = entity.getLocation(useLoc).getY();

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkitModern.java
@@ -16,6 +16,7 @@ package fr.neatmonster.nocheatplus.compat.bukkit;
 
 import java.util.Map;
 
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
@@ -23,6 +24,7 @@ import org.bukkit.block.data.Waterlogged;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 
+import fr.neatmonster.nocheatplus.compat.SchedulerHelper;
 import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitShapeModel;
 import fr.neatmonster.nocheatplus.compat.versions.ClientVersion;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
@@ -61,6 +63,37 @@ public class BlockCacheBukkitModern extends BlockCacheBukkit {
         }
         return super.fetchData(x, y, z);
     }
+
+    @Override
+    public long fetchExtendedData(final int x, final int y, final int z) {
+        if (world == null) {
+            return 0L;
+        }
+        // Folia support: only query live Bukkit block data from the owning region thread.
+        if (SchedulerHelper.isOwnedByCurrentRegion(world, x, z)) {
+            return fetchWaterloggedFlags(x, y, z);
+        }
+        try {
+            if (SchedulerHelper.isOwnedByCurrentRegion(new Location(world, x, y, z))) {
+                return fetchWaterloggedFlags(x, y, z);
+            }
+        } catch (Throwable ignored) {
+            // Keep the cache fallback conservative if the scheduler API is unavailable.
+        }
+        return 0L;
+    }
+
+    private long fetchWaterloggedFlags(final int x, final int y, final int z) {
+        final IPlayerData pData = getPlayerData();
+        if (pData != null && pData.getClientVersion().isLowerThan(ClientVersion.V_1_13)) {
+            return 0L;
+        }
+        final BlockData data = world.getBlockAt(x, y, z).getBlockData();
+        if (data instanceof Waterlogged && ((Waterlogged) data).isWaterlogged()) {
+            return BlockFlags.F_WATER | BlockFlags.F_LIQUID | BlockFlags.F_WATERLOGGED;
+        }
+        return 0L;
+    }
     
     @Override
     public double[] fetchBounds(int x, int y, int z) {
@@ -96,9 +129,15 @@ public class BlockCacheBukkitModern extends BlockCacheBukkit {
     
     @Override
     public boolean standsOnEntity(final Entity entity, final double minX, final double minY, final double minZ, final double maxX, final double maxY, final double maxZ) {
+        if (!SchedulerHelper.isOwnedByCurrentRegion(entity)) {
+            return false;
+        }
         try {
             // TODO: Probably check vehicle ids too before doing this ?
             for (final Entity vehicle : entity.getNearbyEntities(0.1, 2.0, 0.1)) {
+                if (!SchedulerHelper.isOwnedByCurrentRegion(vehicle)) {
+                    continue;
+                }
                 final EntityType type = vehicle.getType();
                 if (!MaterialUtil.isBoat(type) && type != EntityType.SHULKER) { //  && !(vehicle instanceof Minecart)) 
                     continue;
@@ -113,18 +152,5 @@ public class BlockCacheBukkitModern extends BlockCacheBukkit {
             // Ignore exceptions (Context: DisguiseCraft).
         }
         return false;
-    }
-
-    @Override
-    public long fetchExtendedData(int x, int y, int z) {
-        BlockData bd = world.getBlockAt(x, y, z).getBlockData();
-        if (bd instanceof Waterlogged && ((Waterlogged)bd).isWaterlogged()) {
-            final IPlayerData pData = getPlayerData();
-            if (pData != null) {
-                if (pData.getClientVersion().isLowerThan(ClientVersion.V_1_13)) return 0;
-            }
-            return BlockFlags.F_WATER | BlockFlags.F_LIQUID | BlockFlags.F_WATERLOGGED;
-        }
-        return 0;
     }
 }

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BukkitAttributeAccess.java
@@ -67,6 +67,7 @@ public class BukkitAttributeAccess implements IAttributeAccess {
      * @param id
      * @return
      */
+    @SuppressWarnings({"deprecation", "removal"})
     private AttributeModifier getModifier(final AttributeInstance attrInst, final UUID id) {
         for (final AttributeModifier mod : attrInst.getModifiers()) {
             if (id.equals(mod.getUniqueId())) {

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitSnow.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitSnow.java
@@ -21,11 +21,13 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Snow;
 
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
+import fr.neatmonster.nocheatplus.utilities.map.BlockCache.IBlockCacheNode;
 
 public class BukkitSnow implements BukkitShapeModel {
     
-    private static final double[][] SNOW_LAYERS = {
-            null,
+    private static final int MAX_COLLISION_LAYER = 7;
+    private static final double[][] SNOW_COLLISION_LAYERS = {
+            {0.0, 0.0, 0.0, 1.0, 0.0, 1.0},
             {0.0, 0.0, 0.0, 1.0, 0.125, 1.0},
             {0.0, 0.0, 0.0, 1.0, 0.250, 1.0},
             {0.0, 0.0, 0.0, 1.0, 0.375, 1.0},
@@ -38,14 +40,8 @@ public class BukkitSnow implements BukkitShapeModel {
 
     @Override
     public double[] getShape(BlockCache blockCache, World world, int x, int y, int z) {
-        // TODO: Backward Handling
-        final Block block = world.getBlockAt(x, y, z);
-        final BlockState state = block.getState();
-        final BlockData blockData = state.getBlockData();
-        if (blockData instanceof Snow) {
-            return SNOW_LAYERS[((Snow)blockData).getLayers() - 1];
-        }
-        return new double[] {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+        // Snow model: collision height is one layer lower than visual height; one-layer snow has no collision.
+        return SNOW_COLLISION_LAYERS[getCollisionLayer(blockCache, world, x, y, z)];
     }
 
     @Override
@@ -60,12 +56,33 @@ public class BukkitSnow implements BukkitShapeModel {
 
     @Override
     public int getFakeData(BlockCache blockCache, World world, int x, int y, int z) {
-        final Block block = world.getBlockAt(x, y, z);
-        final BlockState state = block.getState();
-        final BlockData blockData = state.getBlockData();
-        if (blockData instanceof Snow) {
-            return ((Snow)blockData).getLayers() - 1;
+        return getCollisionLayer(blockCache, world, x, y, z);
+    }
+
+    private int getCollisionLayer(final BlockCache blockCache, final World world, final int x, final int y, final int z) {
+        if (world != null) {
+            try {
+                final Block block = world.getBlockAt(x, y, z);
+                final BlockState state = block.getState();
+                final BlockData blockData = state.getBlockData();
+                if (blockData instanceof Snow) {
+                    return clampCollisionLayer(((Snow) blockData).getLayers() - 1);
+                }
+            }
+            catch (Throwable ignored) {
+                // Folia/async fallback: use already cached legacy data if it exists, otherwise use no collision.
+            }
+        }
+        if (blockCache != null) {
+            final IBlockCacheNode node = blockCache.getBlockCacheNode(x, y, z);
+            if (node != null && node.isDataFetched()) {
+                return clampCollisionLayer(node.getData());
+            }
         }
         return 0;
+    }
+
+    private int clampCollisionLayer(final int layer) {
+        return Math.max(0, Math.min(MAX_COLLISION_LAYER, layer));
     }
 }

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAliveAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAliveAdapter.java
@@ -44,7 +44,7 @@ public class KeepAliveAdapter extends BaseAdapter {
     private final KeepAliveFrequency frequencyCheck = new KeepAliveFrequency();
 
     public KeepAliveAdapter(Plugin plugin) {
-        super(plugin, ListenerPriority.LOW, PacketType.Play.Client.KEEP_ALIVE);
+        super(plugin, ListenerPriority.LOW, PacketType.Play.Client.KEEP_ALIVE, PacketType.Play.Server.KEEP_ALIVE);
         this.checkType = CheckType.NET_KEEPALIVEFREQUENCY;
         // Add feature tags for checks.
         if (NCPAPIProvider.getNoCheatPlusAPI().getWorldDataManager().isActiveAnywhere(CheckType.NET_KEEPALIVEFREQUENCY)) {
@@ -70,11 +70,12 @@ public class KeepAliveAdapter extends BaseAdapter {
         final IPlayerData pData = DataManager.getPlayerDataSafe(player);
         if (pData == null) return;
         final NetData data = pData.getGenericInstance(NetData.class);
+        recordKeepAlivePacketDetails(event, data, time);
         data.lastKeepAliveTime = time;
         final NetConfig cc = pData.getGenericInstance(NetConfig.class);
 
         // Run check(s).
-        // TODO: Match vs. outgoing keep alive requests.
+        // KeepAlive model: outgoing server ids are recorded in onPacketSending; matching replies are expected.
         // TODO: Better modeling of actual packet sequences (flying vs. keep alive vs. request/ping).
         // TODO: Better integration with god-mode check / trigger reset ndt.
         if (frequencyCheck.isEnabled(player, pData) 
@@ -83,8 +84,25 @@ public class KeepAliveAdapter extends BaseAdapter {
         }
     }
 
+    private void recordKeepAlivePacketDetails(final PacketEvent event, final NetData data, final long time) {
+        final KeepAlivePacketInfo info = KeepAlivePacketInfo.read(event.getPacket());
+        data.recordKeepAlivePacket(time, info.idAvailable, info.id, info.idType, info.longCount, info.intCount,
+                event.isAsync(), Thread.currentThread().getName());
+    }
+
     @Override
     public void onPacketSending(PacketEvent event) {
-        // TODO: Maybe detect if keep alive wasn't asked for + allow cancel.
+        final Player player = event.getPlayer();
+        if (player == null) {
+            return;
+        }
+        final IPlayerData pData = DataManager.getPlayerDataSafe(player);
+        if (pData == null) {
+            return;
+        }
+        final KeepAlivePacketInfo info = KeepAlivePacketInfo.read(event.getPacket());
+        pData.getGenericInstance(NetData.class).recordOutgoingKeepAlivePacket(System.currentTimeMillis(),
+                info.idAvailable, info.id, info.idType, info.longCount, info.intCount,
+                event.isAsync(), Thread.currentThread().getName());
     }
 }

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAlivePacketInfo.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAlivePacketInfo.java
@@ -1,0 +1,74 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.checks.net.protocollib;
+
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.reflect.StructureModifier;
+
+/**
+ * ProtocolLib packet-shape extraction for keepalive request/response ids.
+ */
+final class KeepAlivePacketInfo {
+
+    final boolean idAvailable;
+    final long id;
+    final String idType;
+    final int longCount;
+    final int intCount;
+
+    private KeepAlivePacketInfo(final boolean idAvailable, final long id, final String idType,
+                                final int longCount, final int intCount) {
+        this.idAvailable = idAvailable;
+        this.id = id;
+        this.idType = idType;
+        this.longCount = longCount;
+        this.intCount = intCount;
+    }
+
+    static KeepAlivePacketInfo read(final PacketContainer packet) {
+        boolean idAvailable = false;
+        long id = 0L;
+        String idType = "none";
+        int longCount = -1;
+        int intCount = -1;
+        try {
+            final StructureModifier<Long> longs = packet.getLongs();
+            longCount = longs.size();
+            if (longCount > 0) {
+                final Long value = longs.read(0);
+                if (value != null) {
+                    idAvailable = true;
+                    id = value.longValue();
+                    idType = "long";
+                }
+            }
+        }
+        catch (Throwable ignored) {}
+        try {
+            final StructureModifier<Integer> integers = packet.getIntegers();
+            intCount = integers.size();
+            if (!idAvailable && intCount > 0) {
+                final Integer value = integers.read(0);
+                if (value != null) {
+                    idAvailable = true;
+                    id = value.longValue();
+                    idType = "int";
+                }
+            }
+        }
+        catch (Throwable ignored) {}
+        return new KeepAlivePacketInfo(idAvailable, id, idType, longCount, intCount);
+    }
+}

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/OutgoingPosition.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/OutgoingPosition.java
@@ -117,6 +117,7 @@ public class OutgoingPosition extends BaseAdapter {
         }
 
         final CountableLocation packetData = data.teleportQueue.onOutgoingTeleport(x, y, z, yaw, pitch, teleportId);
+        data.recordOutgoingPosition(x, y, z, yaw, pitch, teleportId, packetData != null, time);
         if (packetData == null) {
             // Add counter for untracked (by Bukkit API) outgoing teleport.
             // TODO: There may be other cases which are indicated by Bukkit API events.

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/UseEntityAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/UseEntityAdapter.java
@@ -33,6 +33,7 @@ import fr.neatmonster.nocheatplus.checks.net.AttackFrequency;
 import fr.neatmonster.nocheatplus.checks.net.NetConfig;
 import fr.neatmonster.nocheatplus.checks.net.NetData;
 import fr.neatmonster.nocheatplus.compat.versions.ServerVersion;
+import fr.neatmonster.nocheatplus.logging.StaticLog;
 import fr.neatmonster.nocheatplus.players.DataManager;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
@@ -104,6 +105,10 @@ public class UseEntityAdapter extends BaseAdapter {
 
     private final LegacyReflectionSet legacySet;
 
+    private volatile boolean protocolLibEntityUseActionBroken = false;
+
+    private volatile boolean protocolLibEntityUseActionWarningLogged = false;
+
     public UseEntityAdapter(Plugin plugin) {
         super(plugin, PacketType.Play.Client.USE_ENTITY);
         this.checkType = CheckType.NET_ATTACKFREQUENCY;
@@ -169,17 +174,20 @@ public class UseEntityAdapter extends BaseAdapter {
         if (!packetInterpreted) {
             // Handle as if latest.
             try {
-                final StructureModifier<EntityUseAction> actions = packet.getEntityUseActions();
-                // TODO: Not sure about version!
-                if (isServerAtLeast1_13) {
-                    final StructureModifier<WrappedEnumEntityUseAction> enumActions = packet.getEnumEntityUseActions();
-                    if (enumActions.size() == 1 && enumActions.read(0).equals(WrappedEnumEntityUseAction.attack())) {
+                if (!protocolLibEntityUseActionBroken) {
+                    final StructureModifier<EntityUseAction> actions = packet.getEntityUseActions();
+                    if (actions.size() == 1) {
                         packetInterpreted = true;
-                        isAttack = true;
+                        isAttack = actions.read(0) == EntityUseAction.ATTACK;
                     }
-                } else if (actions.size() == 1 && actions.read(0) == EntityUseAction.ATTACK) {
-                    packetInterpreted = true;
-                    isAttack = true;
+                    // ProtocolLib compatibility: modern snapshots can throw while initializing enum wrappers.
+                    if (!packetInterpreted && isServerAtLeast1_13) {
+                        final StructureModifier<WrappedEnumEntityUseAction> enumActions = packet.getEnumEntityUseActions();
+                        if (enumActions.size() == 1 && enumActions.read(0).equals(WrappedEnumEntityUseAction.attack())) {
+                            packetInterpreted = true;
+                            isAttack = true;
+                        }
+                    }
                 }
             }
             catch (NullPointerException e) {
@@ -187,6 +195,16 @@ public class UseEntityAdapter extends BaseAdapter {
                  * TODO: Observed somewhere on 1_7_R4, probably a custom build -
                  * why doesn't the LegacyReflectionSet work here?
                  */
+            }
+            catch (LinkageError | RuntimeException e) {
+                protocolLibEntityUseActionBroken = true;
+                if (!protocolLibEntityUseActionWarningLogged) {
+                    protocolLibEntityUseActionWarningLogged = true;
+                    // Diagnostic logging: name the failing branch so attack/combat packet issues are clear in console.
+                    StaticLog.logWarning("ProtocolLib could not expose USE_ENTITY action data (branch=enumEntityUseActions, packet=" + packet.getType() + "). Skipping AttackFrequency interpretation for USE_ENTITY packets until restart.");
+                    StaticLog.logWarning("ProtocolLib USE_ENTITY action failure: " + e.getClass().getName() + ": " + e.getMessage());
+                }
+                return;
             }
         }
         if (!packetInterpreted) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/types/CommandAction.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/types/CommandAction.java
@@ -17,6 +17,7 @@ package fr.neatmonster.nocheatplus.actions.types;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 import fr.neatmonster.nocheatplus.actions.AbstractActionList;
@@ -63,8 +64,8 @@ public class CommandAction<D extends ParameterHolder, L extends AbstractActionLi
     @Override
     public void execute(final D violationData) {
         final String command = getMessage(violationData);
-        SchedulerHelper.runSyncTask(plugin, (arg) -> {
-        	try {
+        final Runnable runCommand = () -> {
+            try {
                 Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), command);
                 if (logDebug) {
                     debug(violationData, command);
@@ -74,7 +75,20 @@ public class CommandAction<D extends ParameterHolder, L extends AbstractActionLi
                 StaticLog.logOnce(Level.WARNING, "Failed to execute the command '" + command + "': " + e.getMessage()
                 + ", please check if everything is setup correct.", StringUtil.throwableToString(e));
             }
-        });
+        };
+        if (plugin == null) {
+            runCommand.run();
+            return;
+        }
+        if (SchedulerHelper.isFoliaServer() && violationData instanceof ViolationData) {
+            final Player player = ((ViolationData) violationData).player;
+            if (player != null) {
+                SchedulerHelper.runSyncTaskForEntity(player, plugin, (arg) -> runCommand.run(),
+                        () -> SchedulerHelper.runSyncTask(plugin, (arg) -> runCommand.run()));
+                return;
+            }
+        }
+        SchedulerHelper.runSyncTask(plugin, (arg) -> runCommand.run());
     }
 
     private void debug(final D violationData, String command) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
@@ -28,6 +28,8 @@ import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.compat.bukkit.BridgePotionEffect;
 import fr.neatmonster.nocheatplus.permissions.Permissions;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.entity.PotionUtil;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
@@ -62,6 +64,11 @@ public class FastBreak extends Check {
                                          // Counting break...break.
                                          : (data.fastBreakBreakTime > now) ? 0 : now - data.fastBreakBreakTime;
 
+        /*
+         * FastBreak compatibility: keep the grace threshold configurable.
+         * The safer modern default belongs in config, while this check only
+         * compares measured block/tool timing against that configured budget.
+         */
         // Check if the time spent is lower than expected.
         if (isInstaBreak.decideOptimistically()) {
             // Ignore these for now.
@@ -80,13 +87,26 @@ public class FastBreak extends Check {
                 // Add as penalty
                 data.fastBreakPenalties.add(now, (float) missingTime);
                 // Only raise a violation, if the total penalty score exceeds the contention duration (for lag, delay).
-                if (data.fastBreakPenalties.score(cc.fastBreakBucketFactor) > cc.fastBreakGrace) {
+                final float penaltyScore = data.fastBreakPenalties.score(cc.fastBreakBucketFactor);
+                if (penaltyScore > cc.fastBreakGrace) {
                     // TODO: maybe add one absolute penalty time for big amounts to stop breaking until then
                     final double violation = (double) missingTime / 1000.0;
                     data.fastBreakVL += violation;
+                    final ItemStack stack = Bridge1_9.getItemInMainHand(player);
+                    final Material toolType = stack == null ? Material.AIR : stack.getType();
+                    final boolean isValidTool = BlockProperties.isValidTool(blockType, stack);
+                    final double haste = PotionUtil.getPotionEffectAmplifier(player, BridgePotionEffect.HASTE);
+                    // Diagnostic info: tag the timing branch so false FastBreak reports show the block/tool context.
+                    final String tags = getFastBreakTags(isInstaBreak, cc, isValidTool, haste, elapsedTime, missingTime);
                     final ViolationData vd = new ViolationData(this, player, data.fastBreakVL, violation, cc.fastBreakActions);
                     if (vd.needsParameters()) {
                         vd.setParameter(ParameterName.BLOCK_TYPE, blockType.toString());
+                        vd.setParameter(ParameterName.TAGS, tags);
+                    }
+                    if (CheckUtils.shouldLogDebugToConsole()) {
+                        logFastBreakDetail(player, blockType, toolType, isInstaBreak, isValidTool, haste,
+                                elapsedTime, expectedBreakingTime, missingTime, serverLagFactor,
+                                penaltyScore, data.fastBreakVL, violation, cc, tags);
                     }
                     cancel = executeActions(vd).willCancel();
                 }
@@ -131,5 +151,70 @@ public class FastBreak extends Check {
             //              player.sendMessage("mc speed: " + x);
             //          }
         }
+    }
+
+    private String getFastBreakTags(final AlmostBoolean isInstaBreak, final BlockBreakConfig cc,
+                                    final boolean isValidTool, final double haste,
+                                    final long elapsedTime, final long missingTime) {
+        // Diagnostic info: these tags describe why the umbrella FastBreak check added VL.
+        final StringBuilder builder = new StringBuilder(120);
+        builder.append("subcheck_fastbreak_timing")
+                .append("+branch_expected_duration")
+                .append(cc.fastBreakStrict ? "+strict_interact_break" : "+break_break")
+                .append("+insta_").append(isInstaBreak.name().toLowerCase())
+                .append(isValidTool ? "+valid_tool" : "+invalid_tool");
+        if (Double.isInfinite(haste)) {
+            builder.append("+no_haste");
+        }
+        else {
+            builder.append("+haste_").append((int) haste + 1);
+        }
+        if (elapsedTime == 0L) {
+            builder.append("+zero_elapsed");
+        }
+        if (missingTime >= 1000L) {
+            builder.append("+large_missing_time");
+        }
+        return builder.toString();
+    }
+
+    private void logFastBreakDetail(final Player player, final Material blockType, final Material toolType,
+                                    final AlmostBoolean isInstaBreak, final boolean isValidTool,
+                                    final double haste, final long elapsedTime,
+                                    final long expectedBreakingTime, final long missingTime,
+                                    final float serverLagFactor, final float penaltyScore,
+                                    final double totalVL, final double addedVL,
+                                    final BlockBreakConfig cc, final String tags) {
+        try {
+            // Diagnostic info: console-only detail for tuning FastBreak grace without changing check behavior.
+            player.getServer().getLogger().info(new StringBuilder(380)
+                    .append("[NCP][FastBreak][detail] player=").append(player.getName())
+                    .append(" uuid=").append(player.getUniqueId())
+                    .append(" subcheck=FASTBREAK_TIMING")
+                    .append(" summary=block_timing{missingMs=").append(missingTime)
+                    .append(",graceMs=").append(StringUtil.fdec3.format(cc.fastBreakGrace))
+                    .append(",tool=").append(isValidTool ? "valid" : "invalid")
+                    .append(",insta=").append(isInstaBreak.name().toLowerCase())
+                    .append('}')
+                    .append(" block=").append(blockType)
+                    .append(" tool=").append(toolType)
+                    .append(" validTool=").append(isValidTool)
+                    .append(" insta=").append(isInstaBreak.name())
+                    .append(" strict=").append(cc.fastBreakStrict)
+                    .append(" elapsedMs=").append(elapsedTime)
+                    .append(" expectedMs=").append(expectedBreakingTime)
+                    .append(" missingMs=").append(missingTime)
+                    .append(" lagFactor=").append(StringUtil.fdec3.format(serverLagFactor))
+                    .append(" penaltyScore=").append(StringUtil.fdec3.format(penaltyScore))
+                    .append(" graceMs=").append(StringUtil.fdec3.format(cc.fastBreakGrace))
+                    .append(" delayMs=").append(cc.fastBreakDelay)
+                    .append(" modSurvival=").append(cc.fastBreakModSurvival)
+                    .append(" haste=").append(Double.isInfinite(haste) ? "none" : Integer.toString((int) haste + 1))
+                    .append(" addVL=").append(StringUtil.fdec3.format(addedVL))
+                    .append(" totalVL=").append(StringUtil.fdec3.format(totalVL))
+                    .append(" tags=").append(tags)
+                    .toString());
+        }
+        catch (Throwable ignored) {}
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatListener.java
@@ -31,6 +31,7 @@ import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.CheckListener;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
+import fr.neatmonster.nocheatplus.checks.net.NetData;
 import fr.neatmonster.nocheatplus.command.CommandUtil;
 import fr.neatmonster.nocheatplus.compat.BridgeMisc;
 import fr.neatmonster.nocheatplus.compat.SchedulerHelper;
@@ -162,6 +163,16 @@ public class ChatListener extends CheckListener implements INotifyReload, JoinLe
         }
     }
 
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerTeleportCommandMonitor(final PlayerCommandPreprocessEvent event) {
+        final String command = getTeleportLikeCommand(event.getMessage());
+        if (command != null) {
+            final Player player = event.getPlayer();
+            DataManager.getPlayerData(player).getGenericInstance(NetData.class)
+                    .recordTeleportCommand(command, player.getLocation(), System.currentTimeMillis());
+        }
+    }
+
     /** We listen to PlayerCommandPreprocess events because commands can be used for spamming too. */
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerCommandPreprocess(final PlayerCommandPreprocessEvent event) {
@@ -224,6 +235,45 @@ public class ChatListener extends CheckListener implements INotifyReload, JoinLe
                 }
             }
         }
+    }
+
+    private String getTeleportLikeCommand(final String message) {
+        if (message == null) {
+            return null;
+        }
+        final String lcMessage = StringUtil.leftTrim(message).toLowerCase();
+        if (lcMessage.length() < 2 || lcMessage.charAt(0) != '/') {
+            return null;
+        }
+        final String[] split = lcMessage.split(" ", 2);
+        String command = split[0].substring(1);
+        final int namespaceIndex = command.indexOf(':');
+        if (namespaceIndex >= 0 && namespaceIndex + 1 < command.length()) {
+            command = command.substring(namespaceIndex + 1);
+        }
+        return isTeleportLikeCommand(command) ? command : null;
+    }
+
+    private boolean isTeleportLikeCommand(final String command) {
+        return command.equals("rtp")
+            || command.equals("randomtp")
+            || command.equals("randomteleport")
+            || command.equals("wild")
+            || command.equals("wilderness")
+            || command.equals("spawn")
+            || command.equals("hub")
+            || command.equals("lobby")
+            || command.equals("home")
+            || command.equals("homes")
+            || command.equals("warp")
+            || command.equals("warps")
+            || command.equals("back")
+            || command.equals("tpa")
+            || command.equals("tpaccept")
+            || command.equals("tpahere")
+            || command.equals("tp")
+            || command.equals("teleport")
+            || command.equals("tphere");
     }
 
     private boolean checkUntrackedLocation(final Player player, final String message, 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Angle.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Angle.java
@@ -30,6 +30,7 @@ import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.checks.ViolationData;
 import fr.neatmonster.nocheatplus.permissions.Permissions;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
 import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.math.TrigUtil;
@@ -113,6 +114,7 @@ public class Angle extends Check {
 
         boolean cancel = false;
         tags.clear();
+        // Diagnostic info: keep stable subcheck tags so combat false positives show which Angle heuristic fired.
 
         // Quick check for expiration of all entries.
         final long time = System.currentTimeMillis();
@@ -221,35 +223,93 @@ public class Angle extends Check {
         if (violationMove > cc.angleMove) {
             violation = violationMove;
             data.angleVL += violation;
+            // Diagnostic info: identify which FightAngle branch crossed its threshold.
+            tags.add(0, "subcheck_angle_move");
             final ViolationData vd = new ViolationData(this, player, data.angleVL, violation, cc.angleActions);
             if (vd.needsParameters()) vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));
+            if (CheckUtils.shouldLogDebugToConsole()) logAngleDetail(player, loc, damagedEntity, "ANGLE_MOVE",
+                    averageMove, averageTime, averageYaw, averageSwitching, data.angleVL, violation);
             cancel = executeActions(vd).willCancel();
         }
         else if (violationTime > cc.angleTime) {
             violation = violationTime;
             data.angleVL += violation;
+            // Diagnostic info: identify which FightAngle branch crossed its threshold.
+            tags.add(0, "subcheck_angle_time");
             final ViolationData vd = new ViolationData(this, player, data.angleVL, violation, cc.angleActions);
             if (vd.needsParameters()) vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));
+            if (CheckUtils.shouldLogDebugToConsole()) logAngleDetail(player, loc, damagedEntity, "ANGLE_TIME",
+                    averageMove, averageTime, averageYaw, averageSwitching, data.angleVL, violation);
             cancel = executeActions(vd).willCancel();
         }
         else if (violationYaw > cc.angleYaw) {
             violation = violationYaw;
             data.angleVL += violation;
+            // Diagnostic info: identify which FightAngle branch crossed its threshold.
+            tags.add(0, "subcheck_angle_yaw");
             final ViolationData vd = new ViolationData(this, player, data.angleVL, violation, cc.angleActions);
             if (vd.needsParameters()) vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));
+            if (CheckUtils.shouldLogDebugToConsole()) logAngleDetail(player, loc, damagedEntity, "ANGLE_YAW",
+                    averageMove, averageTime, averageYaw, averageSwitching, data.angleVL, violation);
             cancel = executeActions(vd).willCancel();
-        } 
+        }
         else if (violationSwitchSpeed > cc.angleSwitch) {
             violation = violationSwitchSpeed;
             data.angleVL += violation;
+            // Diagnostic info: identify which FightAngle branch crossed its threshold.
+            tags.add(0, "subcheck_angle_switch");
             final ViolationData vd = new ViolationData(this, player, data.angleVL, violation, cc.angleActions);
             if (vd.needsParameters()) vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));
+            if (CheckUtils.shouldLogDebugToConsole()) logAngleDetail(player, loc, damagedEntity, "ANGLE_SWITCH",
+                    averageMove, averageTime, averageYaw, averageSwitching, data.angleVL, violation);
             cancel = executeActions(vd).willCancel();
-        } 
+        }
         else {
             // Reward the player by lowering their violation level.
-            data.angleVL *= 0.98D;  
+            data.angleVL *= 0.98D;
         }
         return cancel;
+    }
+
+    private void logAngleDetail(final Player player, final Location loc, final Entity damagedEntity,
+                                final String subCheck, final double averageMove,
+                                final double averageTime, final double averageYaw,
+                                final double averageSwitching, final double totalVL,
+                                final double addedVL) {
+        try {
+            // Diagnostic info: console-only combat angle context for separating aim, timing, and target switching flags.
+            player.getServer().getLogger().info(new StringBuilder(360)
+                    .append("[NCP][FightAngle][detail] player=").append(player.getName())
+                    .append(" uuid=").append(player.getUniqueId())
+                    .append(" subcheck=").append(subCheck)
+                    .append(" summary=").append(subCheck.toLowerCase()).append("{avgMove=")
+                    .append(StringUtil.fdec3.format(averageMove))
+                    .append(",avgTime=").append(StringUtil.fdec3.format(averageTime))
+                    .append(",avgYaw=").append(StringUtil.fdec3.format(averageYaw))
+                    .append(",switch=").append(StringUtil.fdec3.format(averageSwitching))
+                    .append('}')
+                    .append(" target=").append(damagedEntity.getType())
+                    .append(" targetUuid=").append(damagedEntity.getUniqueId())
+                    .append(" avgMove=").append(StringUtil.fdec3.format(averageMove))
+                    .append(" avgTime=").append(StringUtil.fdec3.format(averageTime))
+                    .append(" avgYaw=").append(StringUtil.fdec3.format(averageYaw))
+                    .append(" avgSwitch=").append(StringUtil.fdec3.format(averageSwitching))
+                    .append(" addVL=").append(StringUtil.fdec3.format(addedVL))
+                    .append(" totalVL=").append(StringUtil.fdec3.format(totalVL))
+                    .append(" loc=").append(formatLocation(loc))
+                    .append(" tags=").append(StringUtil.join(tags, "+"))
+                    .toString());
+        }
+        catch (Throwable ignored) {}
+    }
+
+    private String formatLocation(final Location location) {
+        return location == null ? "null"
+                : (location.getWorld() == null ? "null" : location.getWorld().getName())
+                + "@" + StringUtil.fdec3.format(location.getX())
+                + "," + StringUtil.fdec3.format(location.getY())
+                + "," + StringUtil.fdec3.format(location.getZ())
+                + "/" + StringUtil.fdec3.format(location.getYaw())
+                + "," + StringUtil.fdec3.format(location.getPitch());
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Critical.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Critical.java
@@ -32,8 +32,10 @@ import fr.neatmonster.nocheatplus.checks.moving.model.PlayerMoveData;
 import fr.neatmonster.nocheatplus.checks.moving.model.PlayerMoveInfo;
 import fr.neatmonster.nocheatplus.checks.moving.velocity.VelocityFlags;
 import fr.neatmonster.nocheatplus.compat.Bridge1_13;
+import fr.neatmonster.nocheatplus.compat.versions.ClientVersion;
 import fr.neatmonster.nocheatplus.penalties.IPenaltyList;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
 import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.map.BlockFlags;
 import fr.neatmonster.nocheatplus.utilities.moving.AuxMoving;
@@ -43,9 +45,12 @@ import fr.neatmonster.nocheatplus.utilities.moving.MovingUtil;
  * A check used to verify that critical hits done by players are legit.
  */
 public class Critical extends Check {
-    
+
+    // Modern-client model: tiny fall-distance desync can happen during valid low-fall attacks.
+    private static final double MODERN_JUMP_PHASE_CRITICAL_FALL_GRACE = 0.90D;
+
     private final AuxMoving auxMoving = NCPAPIProvider.getNoCheatPlusAPI().getGenericInstance(AuxMoving.class);
-    
+
     /**
      * Instantiates a new critical check.
      */
@@ -100,27 +105,40 @@ public class Critical extends Check {
                 return false;
             }
             
+            final boolean resetCond = moveInfo.from.isResetCond();
+            final boolean slowFalling = !Double.isInfinite(Bridge1_13.getSlowfallingAmplifier(player));
+            final boolean jumpPhaseCritical = mData.sfJumpPhase > 0
+                    && mData.sfJumpPhase <= mData.liftOffEnvelope.getMaxJumpPhase(mData.jumpAmplifier)
+                    && !moveInfo.from.seekCollisionAbove(0.2)
+                    && (lastMove.verVelUsed.isEmpty() || !lastMove.verVelUsed.get(0).hasFlag(VelocityFlags.ORIGIN_BLOCK_BOUNCE))
+                    && !isModernJumpPhaseCriticalGrace(player, pData, mcFallDistance, realisticFallDistance,
+                            mData, thisMove, lastMove, moveInfo);
+            final boolean groundMismatch = Math.abs(ncpFallDistance - mcFallDistance) > 1e-5
+                    && (moveInfo.from.isOnGround() || lastMove.touchedGroundWorkaround);
             boolean isIllegal =
                        // 0: Don't allow players to perform critical hits in blocks where the game would reset fall distance (water, powder snow, bushes, webs, climbables)
-                       moveInfo.from.isResetCond()
+                       resetCond
                        // 0: Same as above. The game resets fall distance with slowfall
-                       || !Double.isInfinite(Bridge1_13.getSlowfallingAmplifier(player))
+                       || slowFalling
                        // 0: A full jump from ground requires more than 6 phases/events.
-                       || mData.sfJumpPhase > 0 && mData.sfJumpPhase <= mData.liftOffEnvelope.getMaxJumpPhase(mData.jumpAmplifier) 
-                       && !moveInfo.from.seekCollisionAbove(0.2) 
-                       && (lastMove.verVelUsed.isEmpty() || !lastMove.verVelUsed.get(0).hasFlag(VelocityFlags.ORIGIN_BLOCK_BOUNCE))
+                       || jumpPhaseCritical
                        // 0: Always invalidate critical hits if we judge the player to be on ground (given enough fall distance)
-                       || Math.abs(ncpFallDistance - mcFallDistance) > 1e-5 && (moveInfo.from.isOnGround() || lastMove.touchedGroundWorkaround)
+                       || groundMismatch
                        // (Let SurvivalFly catch low-jumps).
             ;
 
             // Handle violations
             if (isIllegal) {
+                addCriticalTags(tags, resetCond, slowFalling, jumpPhaseCritical, groundMismatch, lastMove, moveInfo);
                 data.criticalVL += 1.0;
-                // Execute whatever actions are associated with this check and 
+                // Execute whatever actions are associated with this check and
                 //  the violation level and find out if we should cancel the event.
                 final ViolationData vd = new ViolationData(this, player, data.criticalVL, 1.0, cc.criticalActions);
                 if (vd.needsParameters()) vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));
+                if (CheckUtils.shouldLogDebugToConsole()) {
+                    logCriticalDetail(player, loc, data.criticalVL, tags, mcFallDistance, ncpFallDistance,
+                            realisticFallDistance, mData, thisMove, lastMove, moveInfo);
+                }
                 cancel = executeActions(vd).willCancel();
                 // TODO: Introduce penalty instead of cancel.
             }
@@ -129,5 +147,122 @@ public class Critical extends Check {
         }
         auxMoving.returnPlayerMoveInfo(moveInfo);
         return cancel;
+    }
+
+    private void addCriticalTags(final List<String> tags, final boolean resetCond, final boolean slowFalling,
+                                 final boolean jumpPhaseCritical, final boolean groundMismatch,
+                                 final PlayerMoveData lastMove, final PlayerMoveInfo moveInfo) {
+        // Diagnostic info: name the exact Critical branch instead of only reporting FIGHT_CRITICAL.
+        tags.add("subcheck_" + getCriticalSubCheck(resetCond, slowFalling, jumpPhaseCritical, groundMismatch).toLowerCase());
+        if (resetCond) {
+            tags.add("branch_resetcond");
+        }
+        if (slowFalling) {
+            tags.add("branch_slowfall");
+        }
+        if (jumpPhaseCritical) {
+            tags.add("branch_jump_phase");
+        }
+        if (groundMismatch) {
+            tags.add("branch_ground_mismatch");
+        }
+        if (lastMove.touchedGroundWorkaround) {
+            tags.add("branch_lostground");
+        }
+        if (!lastMove.verVelUsed.isEmpty()) {
+            tags.add("branch_velocity");
+        }
+        if (moveInfo.from.isInLiquid() || moveInfo.to.isInLiquid()) {
+            tags.add("branch_liquid");
+        }
+    }
+
+    private String getCriticalSubCheck(final boolean resetCond, final boolean slowFalling,
+                                       final boolean jumpPhaseCritical, final boolean groundMismatch) {
+        if (resetCond) {
+            return "CRITICAL_RESETCOND";
+        }
+        if (slowFalling) {
+            return "CRITICAL_SLOWFALL";
+        }
+        if (jumpPhaseCritical) {
+            return "CRITICAL_JUMP_PHASE";
+        }
+        if (groundMismatch) {
+            return "CRITICAL_GROUND_MISMATCH";
+        }
+        return "CRITICAL_UNKNOWN";
+    }
+
+    private boolean isModernJumpPhaseCriticalGrace(final Player player, final IPlayerData pData,
+                                                   final double mcFallDistance, final double realisticFallDistance,
+                                                   final MovingData mData, final PlayerMoveData thisMove,
+                                                   final PlayerMoveData lastMove,
+                                                   final PlayerMoveInfo moveInfo) {
+        // False-positive model: 1.21+ clients can report valid low-fall attacks inside the old jump-phase window.
+        // This stays a bounded desync model because Bukkit fall distance and NCP movement history update separately.
+        if (pData.getClientVersion() != ClientVersion.HIGHER_THAN_KNOWN_VERSIONS
+                && !pData.getClientVersion().isAtLeast(ClientVersion.V_1_21)) {
+            return false;
+        }
+        if (mcFallDistance > MODERN_JUMP_PHASE_CRITICAL_FALL_GRACE
+                || moveInfo.from.isResetCond()
+                || moveInfo.to.isResetCond()
+                || !lastMove.verVelUsed.isEmpty() && lastMove.verVelUsed.get(0).hasFlag(VelocityFlags.ORIGIN_BLOCK_BOUNCE)) {
+            return false;
+        }
+        final boolean lowFallDesync = player.isOnGround()
+                || thisMove.from.onGround
+                || thisMove.to.onGround
+                || realisticFallDistance > 0.0D
+                || thisMove.yDistance < 0.0D
+                || lastMove.yDistance < 0.0D;
+        return lowFallDesync && mData.sfJumpPhase > 0
+                && mData.sfJumpPhase <= mData.liftOffEnvelope.getMaxJumpPhase(mData.jumpAmplifier);
+    }
+
+    private void logCriticalDetail(final Player player, final Location loc, final double totalVL,
+                                   final List<String> tags, final double mcFallDistance,
+                                   final double ncpFallDistance, final double realisticFallDistance,
+                                   final MovingData mData, final PlayerMoveData thisMove,
+                                   final PlayerMoveData lastMove, final PlayerMoveInfo moveInfo) {
+        try {
+            // Diagnostic info: console-only Critical context for fall distance, ground mismatch, and liquid/reset false flags.
+            player.getServer().getLogger().info(new StringBuilder(420)
+                    .append("[NCP][FightCritical][detail] player=").append(player.getName())
+                    .append(" uuid=").append(player.getUniqueId())
+                    .append(" subcheck=").append(tags.isEmpty() ? "CRITICAL_UNKNOWN" : tags.get(0).substring("subcheck_".length()).toUpperCase())
+                    .append(" summary=").append(tags.isEmpty() ? "critical_unknown" : tags.get(0).substring("subcheck_".length()))
+                    .append("{mcFall=").append(StringUtil.fdec3.format(mcFallDistance))
+                    .append(",ncpFall=").append(StringUtil.fdec3.format(ncpFallDistance))
+                    .append(",realistic=").append(StringUtil.fdec3.format(realisticFallDistance))
+                    .append(",jumpPhase=").append(mData.sfJumpPhase)
+                    .append('}')
+                    .append(" totalVL=").append(StringUtil.fdec3.format(totalVL))
+                    .append(" mcFall=").append(StringUtil.fdec3.format(mcFallDistance))
+                    .append(" ncpFall=").append(StringUtil.fdec3.format(ncpFallDistance))
+                    .append(" realisticFall=").append(StringUtil.fdec3.format(realisticFallDistance))
+                    .append(" jumpPhase=").append(mData.sfJumpPhase)
+                    .append(" liftOff=").append(mData.liftOffEnvelope.name())
+                    .append(" playerGround=").append(player.isOnGround())
+                    .append(" moveGround=").append(thisMove.from.onGround).append("->").append(thisMove.to.onGround)
+                    .append(" infoGround=").append(moveInfo.from.isOnGround()).append("->").append(moveInfo.to.isOnGround())
+                    .append(" reset=").append(moveInfo.from.isResetCond()).append("->").append(moveInfo.to.isResetCond())
+                    .append(" lastTouchedGround=").append(lastMove.touchedGroundWorkaround)
+                    .append(" vVelUsed=").append(lastMove.verVelUsed)
+                    .append(" loc=").append(formatLocation(loc))
+                    .append(" tags=").append(StringUtil.join(tags, "+"))
+                    .toString());
+        }
+        catch (Throwable ignored) {}
+    }
+
+    private String formatLocation(final Location location) {
+        return location == null ? "none"
+                : StringUtil.fdec3.format(location.getX()) + ","
+                + StringUtil.fdec3.format(location.getY()) + ","
+                + StringUtil.fdec3.format(location.getZ()) + "/"
+                + StringUtil.fdec3.format(location.getYaw()) + ","
+                + StringUtil.fdec3.format(location.getPitch());
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Direction.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Direction.java
@@ -20,10 +20,14 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
+import fr.neatmonster.nocheatplus.actions.ParameterName;
 import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.checks.ViolationData;
 import fr.neatmonster.nocheatplus.checks.moving.location.tracking.LocationTrace.ITraceEntry;
 import fr.neatmonster.nocheatplus.compat.MCAccess;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.collision.CollisionUtil;
 import fr.neatmonster.nocheatplus.utilities.math.TrigUtil;
 
@@ -93,7 +97,8 @@ public class Direction extends Check {
             data.directionVL += distance;
             // Execute whatever actions are associated with this check and the violation level and find out if we should
             // cancel the event.
-            cancel = executeActions(player, data.directionVL, distance, cc.directionActions).willCancel();
+            cancel = executeDirectionViolation(player, loc, damaged, damagedIsFake, dLoc, "classic",
+                    off, distance, data, cc, false);
 
             if (cancel) {
                 // Deal an attack penalty time.
@@ -223,7 +228,8 @@ public class Direction extends Check {
 
             // Execute whatever actions are associated with this check and the violation level and find out if we should
             // cancel the event.
-            cancel = executeActions(player, data.directionVL, off, cc.directionActions).willCancel();
+            cancel = executeDirectionViolation(player, loc, damaged, false, damaged.getLocation(), "trace_loop",
+                    context.minResult, off, data, cc, forceViolation);
 
             if (cancel) {
                 // Deal an attack penalty time.
@@ -235,5 +241,61 @@ public class Direction extends Check {
             data.directionVL *= 0.8D;
         }
         return cancel;
+    }
+
+    private boolean executeDirectionViolation(final Player player, final Location loc, final Entity damaged,
+                                              final boolean damagedIsFake, final Location damagedLoc,
+                                              final String branch, final double off, final double addedVL,
+                                              final FightData data, final FightConfig cc,
+                                              final boolean forceViolation) {
+        final ViolationData vd = new ViolationData(this, player, data.directionVL, addedVL, cc.directionActions);
+        if (vd.needsParameters()) {
+            vd.setParameter(ParameterName.TAGS, "branch_" + branch
+                    + "+target_" + damaged.getType()
+                    + (damagedIsFake ? "+fake_target" : "")
+                    + (cc.directionStrict ? "+strict" : "+classic_precision")
+                    + (forceViolation ? "+forced" : ""));
+        }
+        if (CheckUtils.shouldLogDebugToConsole()) {
+            logDirectionDetail(player, loc, damaged, damagedIsFake, damagedLoc, branch, off, addedVL, data.directionVL, cc, forceViolation);
+        }
+        return executeActions(vd).willCancel();
+    }
+
+    private void logDirectionDetail(final Player player, final Location loc, final Entity damaged,
+                                    final boolean damagedIsFake, final Location damagedLoc,
+                                    final String branch, final double off, final double addedVL,
+                                    final double totalVL, final FightConfig cc,
+                                    final boolean forceViolation) {
+        try {
+            player.getServer().getLogger().info(new StringBuilder(360)
+                    .append("[NCP][FightDirection][detail] player=").append(player.getName())
+                    .append(" uuid=").append(player.getUniqueId())
+                    .append(" branch=").append(branch)
+                    .append(" target=").append(damaged.getType())
+                    .append(" targetUuid=").append(damagedIsFake ? "fake" : damaged.getUniqueId())
+                    .append(" fake=").append(damagedIsFake)
+                    .append(" strict=").append(cc.directionStrict)
+                    .append(" force=").append(forceViolation)
+                    .append(" off=").append(StringUtil.fdec3.format(off))
+                    .append(" addVL=").append(StringUtil.fdec3.format(addedVL))
+                    .append(" totalVL=").append(StringUtil.fdec3.format(totalVL))
+                    .append(" playerLoc=").append(formatLocation(loc))
+                    .append(" targetLoc=").append(formatLocation(damagedLoc))
+                    .toString());
+        }
+        catch (Throwable ignored) {}
+    }
+
+    private String formatLocation(final Location location) {
+        if (location == null) {
+            return "null";
+        }
+        return (location.getWorld() == null ? "null" : location.getWorld().getName())
+                + "@" + StringUtil.fdec3.format(location.getX())
+                + "," + StringUtil.fdec3.format(location.getY())
+                + "," + StringUtil.fdec3.format(location.getZ())
+                + "/" + StringUtil.fdec3.format(location.getYaw())
+                + "," + StringUtil.fdec3.format(location.getPitch());
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/generic/block/AbstractBlockDirectionCheck.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/generic/block/AbstractBlockDirectionCheck.java
@@ -23,15 +23,19 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
+import fr.neatmonster.nocheatplus.actions.ParameterName;
 import fr.neatmonster.nocheatplus.actions.ActionList;
 import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.checks.ViolationData;
 import fr.neatmonster.nocheatplus.checks.net.FlyingQueueHandle;
 import fr.neatmonster.nocheatplus.checks.net.FlyingQueueLookBlockChecker;
 import fr.neatmonster.nocheatplus.compat.Bridge1_13;
 import fr.neatmonster.nocheatplus.components.config.ICheckConfig;
 import fr.neatmonster.nocheatplus.components.data.ICheckData;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.collision.tracing.ray.CollideRayVsAABB;
 import fr.neatmonster.nocheatplus.utilities.collision.tracing.ray.ICollideRayVsAABB;
 import fr.neatmonster.nocheatplus.utilities.location.LocUtil;
@@ -148,6 +152,7 @@ public abstract class AbstractBlockDirectionCheck<D extends ICheckData, C extend
         final int blockZ = block.getZ();
         // The distance is squared initially.
         double distance;
+        String branch = "ray_miss";
         if (checker.checkFlyingQueue(x, y, z, loc.getYaw(), loc.getPitch(), 
                 blockX, blockY, blockZ, flyingHandle)) {
             distance = Double.MAX_VALUE;
@@ -156,7 +161,11 @@ public abstract class AbstractBlockDirectionCheck<D extends ICheckData, C extend
             distance = checker.getMinDistance();
         }
 
-        if (face != null && !isInteractable(loc, Location.locToBlock(y), block, face)) distance = 1.0;          
+        // Diagnostic branch: ray misses and unreachable block faces are different root causes.
+        if (face != null && !isInteractable(loc, Location.locToBlock(y), block, face)) {
+            distance = 1.0;
+            branch = "face_unreachable";
+        }
 
         // TODO: Consider a protected field with a tolerance value.
         if (distance != Double.MAX_VALUE) {
@@ -172,7 +181,16 @@ public abstract class AbstractBlockDirectionCheck<D extends ICheckData, C extend
 
             // Execute whatever actions are associated with this check and the violation level and find out if we should
             // cancel the event.
-            cancel = executeActions(player, vl, distance, getActions(cc)).willCancel();
+            // Diagnostic info: preserve the concrete block-direction branch behind interact/place/break direction checks.
+            final String tags = getDiagnosticTags(block, face, branch);
+            final ViolationData vd = new ViolationData(this, player, vl, distance, getActions(cc));
+            if (vd.needsParameters()) {
+                vd.setParameter(ParameterName.TAGS, tags);
+            }
+            if (CheckUtils.shouldLogDebugToConsole()) {
+                logDirectionDetail(player, loc, block, face, branch, distance, vl, tags);
+            }
+            cancel = executeActions(vd).willCancel();
         } else {
             // Player did likely nothing wrong, reduce violation counter to reward them.
             cooldown(player, data, cc);
@@ -219,6 +237,60 @@ public abstract class AbstractBlockDirectionCheck<D extends ICheckData, C extend
 
     private void outputDebugFail(Player player, ICollideRayVsAABB boulder, double distance) {
         debug(player, "Failed: collides: " + boulder.collides() + " , dist: " + distance + " , pos: " + LocUtil.simpleFormat(boulder));
+    }
+
+    private String getDiagnosticTags(final Block block, final BlockFace face, final String branch) {
+        // Diagnostic info: distinguish ray misses from unreachable-face failures in umbrella direction logs.
+        return "subcheck_block_direction"
+                + "+branch_" + branch
+                + "+check_" + type.name().toLowerCase()
+                + "+block_" + block.getType().name().toLowerCase()
+                + (face == null ? "" : "+face_" + face.name().toLowerCase());
+    }
+
+    private void logDirectionDetail(final Player player, final Location loc, final Block block,
+                                    final BlockFace face, final String branch, final double distance,
+                                    final double totalVL, final String tags) {
+        try {
+            // Diagnostic info: console-only block direction context for false positives around stairs, boats, and odd block faces.
+            player.getServer().getLogger().info(new StringBuilder(360)
+                    .append("[NCP][BlockDirection][detail] check=").append(type.name())
+                    .append(" player=").append(player.getName())
+                    .append(" uuid=").append(player.getUniqueId())
+                    .append(" subcheck=BLOCK_DIRECTION")
+                    .append(" summary=block_direction{branch=").append(branch)
+                    .append(",block=").append(block.getType())
+                    .append(",face=").append(face == null ? "none" : face.name().toLowerCase())
+                    .append(",distance=").append(StringUtil.fdec3.format(distance))
+                    .append('}')
+                    .append(" branch=").append(branch)
+                    .append(" block=").append(block.getType())
+                    .append(" face=").append(face == null ? "none" : face.name())
+                    .append(" distance=").append(StringUtil.fdec3.format(distance))
+                    .append(" totalVL=").append(StringUtil.fdec3.format(totalVL))
+                    .append(" playerLoc=").append(formatLocation(loc))
+                    .append(" blockLoc=").append(formatBlockLocation(block))
+                    .append(" yaw=").append(StringUtil.fdec3.format(loc.getYaw()))
+                    .append(" pitch=").append(StringUtil.fdec3.format(loc.getPitch()))
+                    .append(" tags=").append(tags)
+                    .toString());
+        }
+        catch (Throwable ignored) {}
+    }
+
+    private String formatLocation(final Location location) {
+        return location == null ? "null"
+                : (location.getWorld() == null ? "null" : location.getWorld().getName())
+                + "@" + StringUtil.fdec3.format(location.getX())
+                + "," + StringUtil.fdec3.format(location.getY())
+                + "," + StringUtil.fdec3.format(location.getZ());
+    }
+
+    private String formatBlockLocation(final Block block) {
+        return (block.getWorld() == null ? "null" : block.getWorld().getName())
+                + "@" + block.getX()
+                + "," + block.getY()
+                + "," + block.getZ();
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
@@ -105,8 +105,10 @@ public class MovingConfig extends ACheckConfig {
     // Set back policy.
     public final boolean sfSetBackPolicyFallDamage;
     public final ActionList survivalFlyActions;
+    public final boolean sfElytraEnforce;
 
     public final boolean sfHoverCheck; // TODO: Sub check ?
+    public final boolean sfHoverElytraEnforce;
     public final int sfHoverTicks;
     public final int sfHoverLoginTicks;
     public final boolean sfHoverFallDamage;
@@ -221,8 +223,10 @@ public class MovingConfig extends ACheckConfig {
         survivalFlyVLFreezeCount = config.getInt(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZECOUNT);
         survivalFlyVLFreezeInAir = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR);
         survivalFlyActions = config.getOptimizedActionList(ConfPaths.MOVING_SURVIVALFLY_ACTIONS, Permissions.MOVING_SURVIVALFLY);
+        sfElytraEnforce = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_ELYTRA_ENFORCE);
 
         sfHoverCheck = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_HOVER_CHECK);
+        sfHoverElytraEnforce = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_HOVER_ELYTRA_ENFORCE);
         sfHoverTicks = config.getInt(ConfPaths.MOVING_SURVIVALFLY_HOVER_TICKS);
         sfHoverLoginTicks = Math.max(0, config.getInt(ConfPaths.MOVING_SURVIVALFLY_HOVER_LOGINTICKS));
         sfHoverFallDamage = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_HOVER_FALLDAMAGE);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
@@ -233,6 +233,8 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     public double noFallMaxY = 0;
     /** Indicate that NoFall is not to use next damage event for checking on-ground properties. */ 
     public boolean noFallSkipAirCheck = false;
+    /** Elytra NoFall model: last time glide movement reset fall-distance accounting. */
+    public long noFallElytraResetTime = 0L;
     /** Last coordinate from when the player was affected wind charge explosion */
     public Location noFallCurrentLocOnWindChargeHit = null;
 
@@ -249,6 +251,30 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     public int sfHoverTicks = -1;
     /** First count these down before incrementing sfHoverTicks. Set on join, if configured so. */
     public int sfHoverLoginTicks = 0;
+    /** Hover model: airborne ticks included in the accumulated descent budget. */
+    public int hoverAirTicks = 0;
+    /** Hover model: total downward movement expected from gravity/glide prediction, plus unexplained ascent debt. */
+    public double hoverExpectedDrop = 0.0;
+    /** Hover model: total downward movement actually sent by the client. */
+    public double hoverActualDrop = 0.0;
+    /** Hover model: last predicted vertical velocity used for budget continuity. */
+    public double hoverLastYVelocity = 0.0;
+    /** Elytra model: consecutive no-firework upward glide packets outside the energy envelope. */
+    public int elytraNoFireworkAscentTicks = 0;
+    /** Elytra model: accumulated no-firework ascent above speed/dive-derived lift. */
+    public double elytraNoFireworkAscentDebt = 0.0;
+    /** Elytra model diagnostics: allowed upward movement from decayed/dive/speed lift for the last no-firework glide packet. */
+    public double elytraNoFireworkAscentBudget = 0.0;
+    /** Elytra model diagnostics: upward movement above the last no-firework ascent budget. */
+    public double elytraNoFireworkAscentExcess = 0.0;
+    /** Elytra model diagnostics: horizontal speed needed if speed lift alone were explaining the observed ascent. */
+    public double elytraNoFireworkNeededH = Double.NaN;
+    /** Elytra model: session energy bank created by actual no-firework descent. */
+    public double elytraNoFireworkDescentCredit = 0.0;
+    /** Elytra model diagnostics: descent credit used by the last accepted no-firework ascent packet. */
+    public double elytraNoFireworkDescentCreditUsed = 0.0;
+    /** Elytra model: first location of the current no-firework glide session, used as the illegal-ascent correction anchor. */
+    public Location elytraNoFireworkStart = null;
     /** Fake in air flag: set with any violation, reset once on ground. */
     public boolean sfVLInAir = false;
     /** Workarounds (AirWorkarounds,LiquidWorkarounds). */
@@ -349,6 +375,7 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
         removeAllPlayerSpeedModifiers();
         clearWindChargeImpulse();
         sfHoverTicks = sfHoverLoginTicks = -1;
+        resetHoverAirBudget();
         liftOffEnvelope = defaultLiftOffEnvelope;
         vehicleConsistency = MoveConsistency.INCONSISTENT;
         verticalBounce = null;
@@ -378,6 +405,7 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
         // Keep jump amplifier
         // keep jump phase.
         sfHoverTicks = -1; // 0 ?
+        resetHoverAirBudget();
         liftOffEnvelope = defaultLiftOffEnvelope;
         removeAllPlayerSpeedModifiers();
         vehicleConsistency = MoveConsistency.INCONSISTENT; // Not entirely sure here.
@@ -409,7 +437,24 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
         verticalBounce = null;
         // Remember where we send the player to.
         setTeleported(loc);
-        // TODO: sfHoverTicks ?
+        sfHoverTicks = -1;
+        resetHoverAirBudget();
+    }
+
+
+    public void resetHoverAirBudget() {
+        hoverAirTicks = 0;
+        hoverExpectedDrop = 0.0;
+        hoverActualDrop = 0.0;
+        hoverLastYVelocity = 0.0;
+        elytraNoFireworkAscentTicks = 0;
+        elytraNoFireworkAscentDebt = 0.0;
+        elytraNoFireworkAscentBudget = 0.0;
+        elytraNoFireworkAscentExcess = 0.0;
+        elytraNoFireworkNeededH = Double.NaN;
+        elytraNoFireworkDescentCredit = 0.0;
+        elytraNoFireworkDescentCreditUsed = 0.0;
+        elytraNoFireworkStart = null;
     }
 
 
@@ -547,6 +592,25 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
         morePacketsFreq.clear(now);
         morePacketsBurstFreq.clear(now);
         // TODO: Also reset other data ?
+    }
+
+
+    public void onExternalTeleportResync(final Location loc) {
+        // Teleport/Folia support: NET_MOVING accepted a stale pre-teleport packet, so old move history must not
+        // remain available as a future setback target.
+        playerMoves.invalidate();
+        clearPlayerMorePacketsData();
+        sfJumpPhase = 0;
+        sfHoverTicks = -1;
+        resetHoverAirBudget();
+        verticalBounce = null;
+        timeSinceSetBack = 0;
+        if (loc != null && loc.getWorld() != null) {
+            // Folia/teleport safety: packet models can carry coordinate-only targets, but set backs need a real world.
+            setSetBack(loc);
+        }
+        resetTeleported();
+        joinOrRespawn = false;
     }
 
 
@@ -835,14 +899,14 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
      * Set on {@link org.bukkit.event.player.PlayerRiptideEvent} to "MAYBE", as we don't yet know whether the riptide push is applied with or without the 1.2 vertical move from ground.
      */
     public void setTridentReleaseEvent(AlmostBoolean isReleased) {
-        tridentRelease = isReleased;
+        tridentRelease = isReleased == null ? AlmostBoolean.NO : isReleased;
     }
 
     /**
      * Set when pass to PlayerMoveData, also reset state
      */
     public AlmostBoolean consumeTridentReleaseEvent() {
-        final AlmostBoolean result = tridentRelease;
+        final AlmostBoolean result = tridentRelease == null ? AlmostBoolean.NO : tridentRelease;
         tridentRelease = AlmostBoolean.NO;
         return result;
     }
@@ -1021,6 +1085,10 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     public List<PairEntry> useHorizontalVelocity(final double x, final double z) {
         final List<PairEntry> available = horVel.use(x, z, 0.001);
         return available;
+    }
+
+    public List<PairEntry> useHorizontalVelocityCovering(final double x, final double z, final int maxActCount) {
+        return horVel.useCovering(x, z, 1, maxActCount, 0.001);
     }
 
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -47,6 +47,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
 import org.bukkit.event.player.PlayerVelocityEvent;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
 
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
@@ -160,6 +161,32 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
     /** Player names to check hover for, case-insensitive. */
     private final Set<String> hoverTicks = ConcurrentHashMap.newKeySet(30);
+
+    private static final double HOVER_VERTICAL_PROGRESS = 0.04D;
+    private static final double HOVER_AIR_DROP_DEFICIT = 0.60D;
+    /*
+     * Elytra hover model: normal no-firework glides from the tuning logs stayed
+     * below roughly 0.42 accumulated drop debt, while flat hover packets crossed
+     * 0.54 without ever paying real descent. Keep the boundary model-based and
+     * below the packet-shaped hover plateau instead of waiting for the legacy
+     * broad hover window.
+     */
+    private static final double HOVER_ELYTRA_DROP_DEFICIT = 0.52D;
+    /*
+     * Elytra flat-hover model: cheat clients can stay just below the broad drop
+     * deficit by sending repeated tiny/flat glide packets. The latest 1x70 trace
+     * crossed ~0.27 drop debt with essentially zero descent, while legitimate
+     * traces that built similar short-term debt paid real descent, so require
+     * near-zero accumulated descent before using this tighter boundary.
+     */
+    private static final double HOVER_ELYTRA_FLAT_DROP_DEFICIT = 0.25D;
+    private static final double HOVER_ELYTRA_FLAT_MAX_ACTUAL_DROP = 0.02D;
+    private static final double HOVER_ELYTRA_MIN_DESCENT = 0.006D;
+    private static final int HOVER_AIR_BUDGET_MIN_TICKS = 8;
+    private static final int HOVER_ELYTRA_BUDGET_MIN_TICKS = 45;
+    private static final int HOVER_AIR_BUDGET_WINDOW = 80;
+    private static final int HOVER_RECENT_SETBACK_TICKS = 20;
+    private static final long ELYTRA_NOFALL_LANDING_HANDOFF_MS = 1000L;
 
     /** Player names to check enforcing the location for in onTick, case-insensitive. */
     private final Set<String> playersEnforce = ConcurrentHashMap.newKeySet(30);
@@ -297,9 +324,8 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                 if (!MaterialUtil.isBoat(type)) { 
                     continue; 
                 }
-                final Material m = other.getLocation().getBlock().getType();
                 final double locY = other.getLocation().getY();
-                return Math.abs(locY - minY) < 0.7 && BlockProperties.isLiquid(m);
+                return Math.abs(locY - minY) < 1.3;
             }
         return false;
     }
@@ -418,7 +444,8 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         final IPlayerData pData = DataManager.getPlayerData(player);
         final MovingData data = pData.getGenericInstance(MovingData.class);
         data.clearMostMovingCheckData();
-        data.setSetBack(player.getLocation(useDeathLoc)); 
+        // False-positive tuning: do not keep the death location as a valid movement setback for respawn packets.
+        data.resetSetBack();
         if (pData.isDebugActive(checkType)) debug(player, "Death: " + player.getLocation(useDeathLoc));
         useDeathLoc.setWorld(null);
     }
@@ -564,6 +591,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             return;
         }
         final MovingConfig cc = pData.getGenericInstance(MovingConfig.class);
+        pData.getGenericInstance(NetData.class).recordTeleportEvent(to, event.getCause().name());
         // Detect our own player set backs.
         if (data.hasTeleported() && onPlayerTeleportMonitorHasTeleported(player, event, to, data, cc, pData)) {
             data.clearWindChargeImpulse(); // Always clear this data.
@@ -573,8 +601,9 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         boolean skipExtras = false; // Skip extra data adjustments during special teleport, e.g. vehicle set back.
         // Detect our own vehicle set backs (...).
         if (data.isVehicleSetBack) {
-            // Uncertain if this is vehicle leave or vehicle enter.
-            if (event.getCause() != BridgeMisc.TELEPORT_CAUSE_CORRECTION_OF_POSITION) {
+            // Folia/false-positive tuning: vehicle corrections can surface as DISMOUNT teleports on modern servers.
+            if (event.getCause() != BridgeMisc.TELEPORT_CAUSE_CORRECTION_OF_POSITION
+                    && event.getCause() != TeleportCause.DISMOUNT) {
                 // TODO: Unexpected, what now?
                 NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, CheckUtils.getLogMessagePrefix(player, CheckType.MOVING_VEHICLE) + "Unexpected teleport cause on vehicle set back: " + event.getCause());
             }
@@ -714,15 +743,52 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         data.lastMoveTime = now; 
         mData.mcFallDistance = player.getFallDistance();
         final Location from = event.getFrom();
+        final Location to = event.getTo();
+        if (!isFoliaMoveRegionSafe(from, to)) {
+            if (pData.isDebugActive(checkType)) {
+                debugUnsafeFoliaMove(player, "Skip PlayerMoveEvent monitor", from, to);
+            }
+            return;
+        }
         // Feed yawrate and reset moving data positions if necessary.
         final int tick = TickTask.getTick();
         final MovingConfig mCc = pData.getGenericInstance(MovingConfig.class);
         if (!event.isCancelled()) {
             final Location pLoc = player.getLocation(useLoc);
-            onMoveMonitorNotCancelled(player, TrigUtil.isSamePosAndLook(pLoc, from) ? from : pLoc, event.getTo(), now, tick, data, mData, mCc, pData);
+            onMoveMonitorNotCancelled(player, TrigUtil.isSamePosAndLook(pLoc, from) ? from : pLoc, to, now, tick, data, mData, mCc, pData);
             useLoc.setWorld(null);
         }
         else onCancelledMove(player, from, tick, now, mData, mCc, data, pData);
+    }
+
+    private boolean isFoliaMoveRegionSafe(final Location from, final Location to) {
+        return !SchedulerHelper.isFoliaServer()
+            || SchedulerHelper.isOwnedByCurrentRegion(from, 1)
+            && SchedulerHelper.isOwnedByCurrentRegion(to, 1);
+    }
+
+    private String formatFoliaMoveLocation(final Location location) {
+        return location == null ? "null" : LocUtil.simpleFormat(location);
+    }
+
+    private void debugUnsafeFoliaMove(final Player player, final String prefix, final Location from, final Location to) {
+        debug(player, prefix + ": movement touches a non-owned Folia region. from: "
+            + formatFoliaMoveLocation(from) + " , to: " + formatFoliaMoveLocation(to));
+    }
+
+    private void skipUnsafeFoliaMove(final Player player, final Location from, final Location to, final MovingData data, final boolean debug) {
+        final Location ref = to != null ? to : from;
+        data.clearMostMovingCheckData();
+        if (ref != null) {
+            data.setSetBack(ref);
+            data.lastY = ref.getY();
+        }
+        data.joinOrRespawn = false;
+        data.lastMoveNoMove = false;
+        processingEvents.remove(player.getName());
+        if (debug) {
+            debugUnsafeFoliaMove(player, "Skip PlayerMoveEvent checks", from, to);
+        }
     }
     
 
@@ -743,6 +809,14 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         /** New "to" location where to set back the player to. Requested by vehicle checks */
         Location newTo = null;
         data.increasePlayerMoveCount();
+        if (!isFoliaMoveRegionSafe(from, to)) {
+            skipUnsafeFoliaMove(player, from, to, data, debug);
+            return;
+        }
+        if (SchedulerHelper.isFoliaServer() && player.isInsideVehicle() && !SchedulerHelper.isOwnedByCurrentRegion(player.getVehicle())) {
+            skipUnsafeFoliaMove(player, from, to, data, debug);
+            return;
+        }
 
         ////////////////////////////////////////////////////
         // Early return tests (no full processing).       //
@@ -756,6 +830,14 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             newTo = vehicleChecks.onPlayerMoveVehicle(player, from, to, data, pData);
             earlyReturn = true;
             token = "vehicle";
+        }
+        else if (standsOnEntity(player, Math.min(from.getY(), to.getY()))) {
+            // Standing on boats produces player moves from the support/passenger
+            // handoff that do not follow the normal walking/jumping envelope.
+            data.setSetBack(to);
+            data.survivalFlyVL *= 0.95;
+            earlyReturn = true;
+            token = "boat-support";
         }
         else if (data.lastVehicleType == EntityType.MINECART && ServerIsAtLeast1_19_4
             // The setback comes from VehicleChecks#onPlayerVehicleLeave
@@ -1106,6 +1188,10 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                             currentToIndex = count >= maxSplit ? -1 : i;
                             /* The 'to' location skipped/lost by Bukkit in the flying queue. Use Bukkit's "to" if the maximum split was reached */
                             Location packetTo = count >= maxSplit ? to : new Location(from.getWorld(), filteredFlyingQueue[i].getX(), filteredFlyingQueue[i].getY(), filteredFlyingQueue[i].getZ(), currentYaw, currentPitch);
+                            if (!isFoliaMoveRegionSafe(packet, packetTo)) {
+                                skipUnsafeFoliaMove(player, packet, packetTo, data, debug);
+                                break;
+                            }
                             // Finally, set the moving data to be used by checks.
                             moveInfo.set(player, packet, packetTo, cc.yOnGround);
                             // Finally, remap the input for this move.
@@ -1160,6 +1246,10 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
      */
     private void bukkitSplitMove(final Player player, final PlayerMoveInfo moveInfo, final Location from, final Location loc, final Location to, 
                                  final boolean debug, final MovingData data, final MovingConfig cc, final IPlayerData pData, final PlayerMoveEvent event) {
+        if (!isFoliaMoveRegionSafe(from, loc) || !isFoliaMoveRegionSafe(loc, to)) {
+            skipUnsafeFoliaMove(player, from, to, data, debug);
+            return;
+        }
         // 1: Use player#getLocation() as the "to" location (from->loc).
         moveInfo.set(player, from, loc, cc.yOnGround);
         if (debug) {
@@ -1265,6 +1355,13 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         final PlayerLocation pFrom, pTo;
         pFrom = moveInfo.from;
         pTo = moveInfo.to;
+
+        // Teleport/Folia model: NET_MOVING can detect a server-side position jump before Bukkit teleport
+        // monitor data is visible, so retire stale movement history from the safe move-event thread too.
+        if (pData.getGenericInstance(NetData.class).applyPendingTeleportResync(player, data, from, to, time)
+                && debug) {
+            debug(player, "Applied pending NET_MOVING teleport resync before movement checks.");
+        }
         
         
         ////////////////////////////////////
@@ -1293,6 +1390,9 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         thisMove.setBackYDistance = pTo.getY() - data.getSetBackY();
         thisMove.isGliding = Bridge1_9.isGliding(player);
         thisMove.tridentRelease = data.consumeTridentReleaseEvent();
+        if (isElytraNoFallResetMove(player, thisMove)) {
+            resetNoFallForElytraGlide(player, pTo, data, time);
+        }
 
         ////////////////////////////
         // Potion effect "Jump".  //
@@ -1501,17 +1601,14 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             // 1.4: Only check NoFall, if not already vetoed.
             if (checkNf) {
                 checkNf = noFall.isEnabled(player, pData);
+                if (checkNf && isRecentElytraNoFallReset(data, time)) {
+                    checkNf = false;
+                }
             }
             
             // 1.5: Hover subcheck.
             if (newTo == null) {
-                // TODO: Could reset for from-on-ground as well, for not too big moves.
-                if (cc.sfHoverCheck && !(lastMove.toIsValid && lastMove.to.extraPropertiesValid && lastMove.to.onGroundOrResetCond) && !pTo.isOnGround()) {
-                    // Start counting ticks.
-                    hoverTicks.add(playerName);
-                    data.sfHoverTicks = 0;
-                }
-                else data.sfHoverTicks = -1;
+                updateHoverTracking(player, playerName, pFrom, pTo, thisMove, lastMove, data, cc, debug);
 
                 // Still check for NoFall.
                 if (checkNf) {
@@ -1636,6 +1733,220 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             prepareSetBack(player, event, newTo, data, cc, pData);
             return true;
         }
+    }
+
+    private boolean isElytraNoFallResetMove(final Player player, final PlayerMoveData thisMove) {
+        return thisMove.isGliding || Bridge1_9.isGlidingWithElytra(player);
+    }
+
+    private boolean isRecentElytraNoFallReset(final MovingData data, final long now) {
+        return data.noFallElytraResetTime > 0L
+            && now >= data.noFallElytraResetTime
+            && now - data.noFallElytraResetTime <= ELYTRA_NOFALL_LANDING_HANDOFF_MS;
+    }
+
+    private void resetNoFallForElytraGlide(final Player player, final PlayerLocation to,
+                                           final MovingData data, final long now) {
+        /*
+         * Elytra NoFall model: while the server accepts gliding, fall damage is
+         * governed by the elytra glide/collision model, not by ordinary vertical
+         * drop accumulation. Keep a short handoff for the landing damage event.
+         */
+        data.clearNoFallData();
+        data.noFallMaxY = to.getY();
+        data.noFallElytraResetTime = now;
+        if (player.getFallDistance() > 0f) {
+            player.setFallDistance(0f);
+        }
+    }
+
+    private void updateHoverTracking(final Player player, final String playerName, final PlayerLocation from,
+                                     final PlayerLocation to, final PlayerMoveData thisMove,
+                                     final PlayerMoveData lastMove, final MovingData data, final MovingConfig cc,
+                                     final boolean debug) {
+        if (!shouldTrackHover(player, from, to, lastMove, cc)) {
+            data.sfHoverTicks = -1;
+            data.resetHoverAirBudget();
+            return;
+        }
+        hoverTicks.add(playerName);
+        if (isHoverMovementExempt(player, from, to, thisMove, data)) {
+            data.sfHoverTicks = 0;
+            data.resetHoverAirBudget();
+            return;
+        }
+        final boolean gliding = thisMove.isGliding || Bridge1_9.isGlidingWithElytra(player);
+        final boolean descentBudgetDeficit = hasHoverDescentBudgetDeficit(player, thisMove, data);
+        if (gliding && !isElytraHoverEnforced(cc)) {
+            /*
+             * Elytra hover data collection: keep the descent budget and flightTrace
+             * diagnostics updated, but do not schedule a hover correction until the
+             * model is explicitly enabled in config.
+             */
+            data.sfHoverTicks = -1;
+            hoverTicks.remove(playerName);
+            if (debug && descentBudgetDeficit) {
+                debug(player, "Elytra hover data-only: descent budget deficit"
+                    + " yDist=" + StringUtil.fdec6.format(thisMove.yDistance)
+                    + " hDist=" + StringUtil.fdec6.format(thisMove.hDistance)
+                    + " airTicks=" + data.hoverAirTicks
+                    + " expectedDrop=" + StringUtil.fdec6.format(data.hoverExpectedDrop)
+                    + " actualDrop=" + StringUtil.fdec6.format(data.hoverActualDrop)
+                    + " lastYVelocity=" + StringUtil.fdec6.format(data.hoverLastYVelocity));
+            }
+            return;
+        }
+        if (!descentBudgetDeficit) {
+            // Hover model: real descent progress keeps the accumulated budget healthy.
+            data.sfHoverTicks = 0;
+            return;
+        }
+        if (gliding) {
+            /*
+             * Elytra hover model: once the descent budget model rejects the glide,
+             * do not wait for the legacy hover timer. The legacy timer was letting
+             * packet-shaped hover toggle below the threshold before correction.
+             */
+            data.sfHoverTicks = Math.max(data.sfHoverTicks, cc.sfHoverTicks + hoverTicksStep);
+            return;
+        }
+        if (data.sfHoverTicks < 0) {
+            data.sfHoverTicks = 0;
+            if (debug) {
+                debug(player, "Start hover tracking: descent budget deficit"
+                    + " yDist=" + StringUtil.fdec6.format(thisMove.yDistance)
+                    + " hDist=" + StringUtil.fdec6.format(thisMove.hDistance)
+                    + " gliding=" + thisMove.isGliding
+                    + " airTicks=" + data.hoverAirTicks
+                    + " expectedDrop=" + StringUtil.fdec6.format(data.hoverExpectedDrop)
+                    + " actualDrop=" + StringUtil.fdec6.format(data.hoverActualDrop));
+            }
+        }
+    }
+
+
+    private boolean isElytraHoverEnforced(final MovingConfig cc) {
+        /*
+         * Elytra hover is part of the active elytra movement model. Keep the
+         * dedicated hover switch for staged testing, but also enforce it when
+         * the broader SurvivalFly elytra model is enabled.
+         */
+        return cc.sfHoverElytraEnforce || cc.sfElytraEnforce;
+    }
+
+
+    private boolean shouldTrackHover(final Player player, final PlayerLocation from, final PlayerLocation to,
+                                     final PlayerMoveData lastMove, final MovingConfig cc) {
+        if (!cc.sfHoverCheck || player.isDead() || player.isSleeping() || player.isInsideVehicle()
+                || player.isFlying() || player.getAllowFlight()) {
+            return false;
+        }
+        if (to.isOnGroundOrResetCond() || from.isOnGroundOrResetCond()) {
+            return false;
+        }
+        return !(lastMove.toIsValid && lastMove.to.extraPropertiesValid && lastMove.to.onGroundOrResetCond);
+    }
+
+
+    private boolean isHoverMovementExempt(final Player player, final PlayerLocation from, final PlayerLocation to,
+                                          final PlayerMoveData thisMove, final MovingData data) {
+        if (data.timeSinceSetBack < HOVER_RECENT_SETBACK_TICKS || data.hasTeleported()
+                || data.joinOrRespawn || data.timeRiptiding + 1500 > System.currentTimeMillis()) {
+            return true;
+        }
+        if (from.isResetCond() || to.isResetCond() || from.isInLiquid() || to.isInLiquid()
+                || from.isOnClimbable() || to.isOnClimbable() || from.isInWeb() || to.isInWeb()
+                || from.isInPowderSnow() || to.isInPowderSnow()) {
+            return true;
+        }
+        if (!Double.isInfinite(Bridge1_13.getSlowfallingAmplifier(player))) {
+            return true;
+        }
+        final boolean gliding = thisMove.isGliding || Bridge1_9.isGlidingWithElytra(player);
+        if (data.hasQueuedVerVel() || data.getHorizontalVelocityTracker().hasQueued()) {
+            return true;
+        }
+        if (gliding) {
+            /*
+             * Elytra anti-hover model: firework/riptide/velocity cases are handled
+             * elsewhere. Plain gliding is allowed to climb briefly, but sustained
+             * no-firework hover has to pay the accumulated descent budget.
+             */
+            return data.fireworksBoostDuration > 0;
+        }
+        return player.getVelocity().getY() > HOVER_VERTICAL_PROGRESS;
+    }
+
+
+    private boolean hasHoverDescentBudgetDeficit(final Player player, final PlayerMoveData thisMove,
+                                                 final MovingData data) {
+        final boolean gliding = thisMove.isGliding || Bridge1_9.isGlidingWithElytra(player);
+        final double expectedY = getHoverExpectedY(player, thisMove, data, gliding);
+        final int minTicks = gliding ? HOVER_ELYTRA_BUDGET_MIN_TICKS : HOVER_AIR_BUDGET_MIN_TICKS;
+        final double allowedDeficit = gliding ? HOVER_ELYTRA_DROP_DEFICIT : HOVER_AIR_DROP_DEFICIT;
+        data.hoverAirTicks++;
+        data.hoverExpectedDrop += Math.max(0.0D, -expectedY) + getHoverUnexpectedAscentDebt(thisMove, gliding);
+        data.hoverActualDrop += Math.max(0.0D, -thisMove.yDistance);
+        if (data.hoverActualDrop > data.hoverExpectedDrop + allowedDeficit) {
+            // Hover model: cap old descent credit so a past dive cannot bankroll future hovering.
+            data.hoverActualDrop = data.hoverExpectedDrop + allowedDeficit;
+        }
+        data.hoverLastYVelocity = expectedY;
+        trimHoverAirBudget(data);
+
+        final double deficit = data.hoverExpectedDrop - data.hoverActualDrop;
+        final boolean flatNoDropGlide = gliding
+                && data.hoverAirTicks >= minTicks
+                && data.hoverActualDrop <= HOVER_ELYTRA_FLAT_MAX_ACTUAL_DROP
+                && deficit > HOVER_ELYTRA_FLAT_DROP_DEFICIT;
+        return data.hoverAirTicks >= minTicks && (deficit > allowedDeficit || flatNoDropGlide)
+            && (gliding || Math.abs(thisMove.yDistance) < HOVER_VERTICAL_PROGRESS
+                || thisMove.yDistance > expectedY + Magic.PREDICTION_EPSILON);
+    }
+
+
+    private double getHoverUnexpectedAscentDebt(final PlayerMoveData thisMove, final boolean gliding) {
+        if (!gliding || thisMove.yDistance <= 0.0D) {
+            return 0.0D;
+        }
+        /*
+         * Elytra anti-hover model: climbing without a firework is worse than simply
+         * missing descent, so count movement above the vanilla glide envelope as
+         * vertical debt in the same accumulated budget.
+         */
+        final double modelUpper = Math.max(0.0D, thisMove.yAllowedDistance);
+        return Math.max(0.0D, thisMove.yDistance - modelUpper);
+    }
+
+
+    private double getHoverExpectedY(final Player player, final PlayerMoveData thisMove,
+                                     final MovingData data, final boolean gliding) {
+        double expectedY = thisMove.yAllowedDistance;
+        if (Double.isNaN(expectedY) || Double.isInfinite(expectedY)) {
+            expectedY = 0.0D;
+        }
+        if (gliding) {
+            /*
+             * Elytra hover model: gliding may trade speed for lift, but without a
+             * firework or queued server velocity it still needs a downward budget
+             * over time. Horizontal progress alone must not reset hover.
+             */
+            return Math.min(expectedY, -HOVER_ELYTRA_MIN_DESCENT);
+        }
+        if (expectedY > -Magic.PREDICTION_EPSILON) {
+            expectedY = (data.hoverLastYVelocity - Magic.DEFAULT_GRAVITY) * Magic.FRICTION_MEDIUM_AIR;
+        }
+        return expectedY;
+    }
+
+
+    private void trimHoverAirBudget(final MovingData data) {
+        if (data.hoverAirTicks <= HOVER_AIR_BUDGET_WINDOW) {
+            return;
+        }
+        data.hoverAirTicks = HOVER_AIR_BUDGET_WINDOW / 2;
+        data.hoverExpectedDrop *= 0.5D;
+        data.hoverActualDrop *= 0.5D;
     }
 
 
@@ -1981,13 +2292,27 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     private void onMoveMonitorNotCancelled(final Player player, final Location from, final Location to, 
                                            final long now, final long tick, final CombinedData data, 
                                            final MovingData mData, final MovingConfig mCc, final IPlayerData pData) {
-        final String toWorldName = to.getWorld().getName();
         final boolean debug = pData.isDebugActive(checkType);
+        if (!isFoliaMoveRegionSafe(from, to)) {
+            if (debug) {
+                debugUnsafeFoliaMove(player, "Skip PlayerMoveEvent monitor follow-up", from, to);
+            }
+            return;
+        }
+        final String toWorldName = to.getWorld().getName();
         Combined.feedYawRate(player, to.getYaw(), now, toWorldName, data, pData);
         // TODO: maybe even not count vehicles at all ?
         if (player.isInsideVehicle()) {
             // TODO: refine (!).
-            final Location ref = player.getVehicle().getLocation(useLoc);
+            final Entity vehicle = player.getVehicle();
+            if (!SchedulerHelper.isOwnedByCurrentRegion(vehicle)) {
+                if (debug) {
+                    debug(player, "Skip PlayerMoveEvent vehicle monitor follow-up: vehicle is not owned by the current Folia region.");
+                }
+                mData.clearVehicleData();
+                return;
+            }
+            final Location ref = vehicle.getLocation(useLoc);
             aux.resetPositionsAndMediumProperties(player, ref, mData, mCc); // TODO: Consider using to and intercept cheat attempts in another way.
             useLoc.setWorld(null);
             mData.updateTrace(player, to, tick, mcAccess.getHandle()); // TODO: Can you become invincible by sending special moves?
@@ -2155,6 +2480,18 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     private void checkFallDamageEvent(final Player player, final EntityDamageEvent event) {
         final IPlayerData pData = DataManager.getPlayerData(player);
         final MovingData data = pData.getGenericInstance(MovingData.class);
+        final long now = System.currentTimeMillis();
+        if (Bridge1_9.isGlidingWithElytra(player) || isRecentElytraNoFallReset(data, now)) {
+            /*
+             * Elytra NoFall model: valid glide descent should not become stored
+             * ordinary fall distance on the landing packet or the following fall
+             * damage event. SurvivalFly handles invalid gliding separately.
+             */
+            event.setCancelled(true);
+            data.clearNoFallData();
+            player.setFallDistance(0f);
+            return;
+        }
         if (player.isInsideVehicle()) {
             // Ignore vehicles (noFallFallDistance will be inaccurate anyway).
             data.clearNoFallData();
@@ -2453,15 +2790,30 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         // TODO: Change to per world checking (as long as configs are per world).
         // Legacy: enforcing location consistency.
         if (!playersEnforce.isEmpty()) {
-            checkOnTickPlayersEnforce();
+            if (SchedulerHelper.isFoliaServer()) {
+                checkOnTickPlayersEnforceFolia();
+            }
+            else {
+                checkOnTickPlayersEnforce();
+            }
         }
         // Hover check (SurvivalFly).
         if (tick % hoverTicksStep == 0 && !hoverTicks.isEmpty()) {
             // Only check every so and so ticks.
-            checkOnTickHover();
+            if (SchedulerHelper.isFoliaServer()) {
+                checkOnTickHoverFolia();
+            }
+            else {
+                checkOnTickHover();
+            }
         }
         // Cleanup.
         useTickLoc.setWorld(null);
+    }
+
+
+    private Plugin getPlugin() {
+        return Bukkit.getPluginManager().getPlugin("NoCheatPlus");
     }
 
 
@@ -2484,7 +2836,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             final MovingData data = pData.getGenericInstance(MovingData.class);
             if (player.isDead() || player.isSleeping() || player.isInsideVehicle()) {
                 data.sfHoverTicks = -1;
-                // (Removed below.)
+                data.resetHoverAirBudget();
             }
             if (data.sfHoverTicks < 0) {
                 data.sfHoverLoginTicks = 0;
@@ -2501,6 +2853,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             if (!cc.sfHoverCheck) {
                 rem.add(playerName);
                 data.sfHoverTicks = -1;
+                data.resetHoverAirBudget();
                 continue;
             }
             // Increase ticks here.
@@ -2515,6 +2868,82 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         }
         hoverTicks.removeAll(rem);
         aux.returnPlayerMoveInfo(info);
+    }
+
+
+    /**
+     * Folia requires block/entity reads to happen on the owning entity's
+     * scheduler. The global tick task only dispatches the hover work.
+     */
+    private void checkOnTickHoverFolia() {
+        final Plugin plugin = getPlugin();
+        if (plugin == null) {
+            return;
+        }
+        for (final String playerName : hoverTicks) {
+            final Player player = DataManager.getPlayerExact(playerName);
+            if (player == null) {
+                hoverTicks.remove(playerName);
+                continue;
+            }
+            SchedulerHelper.runSyncTaskForEntity(player, plugin, (arg) -> {
+                final PlayerMoveInfo info = aux.usePlayerMoveInfo();
+                try {
+                    final List<String> rem = new ArrayList<String>(1);
+                    synchronized (this) {
+                        checkOnTickHover(playerName, info, rem);
+                    }
+                    if (!rem.isEmpty()) {
+                        hoverTicks.removeAll(rem);
+                    }
+                }
+                finally {
+                    aux.returnPlayerMoveInfo(info);
+                }
+            }, () -> hoverTicks.remove(playerName));
+        }
+    }
+
+
+    private void checkOnTickHover(final String playerName, final PlayerMoveInfo info, final List<String> rem) {
+        final Player player = DataManager.getPlayerExact(playerName);
+        if (player == null || !player.isOnline()) {
+            rem.add(playerName);
+            return;
+        }
+        final IPlayerData pData = DataManager.getPlayerData(player);
+        final MovingData data = pData.getGenericInstance(MovingData.class);
+        if (player.isDead() || player.isSleeping() || player.isInsideVehicle()) {
+            data.sfHoverTicks = -1;
+            data.resetHoverAirBudget();
+        }
+        if (data.sfHoverTicks < 0) {
+            data.sfHoverLoginTicks = 0;
+            rem.add(playerName);
+            return;
+        }
+        else if (data.sfHoverLoginTicks > 0) {
+            // Additional "grace period".
+            data.sfHoverLoginTicks --;
+            return;
+        }
+        final MovingConfig cc = pData.getGenericInstance(MovingConfig.class);
+        // Check if enabled at all.
+        if (!cc.sfHoverCheck) {
+            rem.add(playerName);
+            data.sfHoverTicks = -1;
+            data.resetHoverAirBudget();
+            return;
+        }
+        // Increase ticks here.
+        data.sfHoverTicks += hoverTicksStep;
+        if (data.sfHoverTicks < cc.sfHoverTicks) {
+            // Don't do the heavier checking here, let moving checks reset these.
+            return;
+        }
+        if (checkHover(player, data, cc, pData, info)) {
+            rem.add(playerName);
+        }
     }
 
 
@@ -2544,6 +2973,49 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         }
         if (!rem.isEmpty()) {
             playersEnforce.removeAll(rem);
+        }
+    }
+
+
+    /**
+     * Folia requires player location reads and corrective teleports to happen
+     * on the player's entity scheduler.
+     */
+    private void checkOnTickPlayersEnforceFolia() {
+        final Plugin plugin = getPlugin();
+        if (plugin == null) {
+            return;
+        }
+        for (final String playerName : playersEnforce) {
+            final Player player = DataManager.getPlayerExact(playerName);
+            if (player == null) {
+                playersEnforce.remove(playerName);
+                continue;
+            }
+            SchedulerHelper.runSyncTaskForEntity(player, plugin, (arg) -> {
+                synchronized (this) {
+                    checkOnTickPlayerEnforce(playerName);
+                }
+            }, () -> playersEnforce.remove(playerName));
+        }
+    }
+
+
+    private void checkOnTickPlayerEnforce(final String playerName) {
+        final Player player = DataManager.getPlayerExact(playerName);
+        if (player == null || !player.isOnline()) {
+            playersEnforce.remove(playerName);
+            return;
+        }
+        else if (player.isDead() || player.isSleeping() || player.isInsideVehicle()) {
+            // Don't remove but also don't check [subject to change].
+            return;
+        }
+        final MovingData data = DataManager.getGenericInstance(player, MovingData.class);
+        final Location newTo = enforceLocation(player, player.getLocation(useTickLoc), data);
+        if (newTo != null) {
+            data.prepareSetBack(newTo);
+            SchedulerHelper.teleportEntity(player, newTo, BridgeMisc.TELEPORT_CAUSE_CORRECTION_OF_POSITION);
         }
     }
 
@@ -2580,6 +3052,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         if (info.from.isOnGroundOrResetCond() || info.from.isAboveLadder()) {
             res = true;
             data.sfHoverTicks = 0;
+            data.resetHoverAirBudget();
         }
         else {
             if (data.sfHoverTicks > cc.sfHoverTicks) {
@@ -2609,9 +3082,20 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     private void handleHoverViolation(final Player player, final PlayerLocation loc, 
                                       final MovingConfig cc, final MovingData data, final IPlayerData pData) {
         // Check nofall damage (!).
-        if (cc.sfHoverFallDamage && noFall.isEnabled(player, pData)) {
+        final long now = System.currentTimeMillis();
+        if (cc.sfHoverFallDamage && noFall.isEnabled(player, pData)
+                && !Bridge1_9.isGlidingWithElytra(player)
+                && !isRecentElytraNoFallReset(data, now)) {
             // Consider adding 3/3.5 to fall distance if fall distance > 0?
             noFall.checkDamage(player, loc.getY(), data, pData);
+        }
+        if (pData.isDebugActive(checkType)) {
+            final double deficit = data.hoverExpectedDrop - data.hoverActualDrop;
+            debug(player, "Hover descent budget violation: hoverAirTicks=" + data.hoverAirTicks
+                    + " hoverExpectedDrop=" + StringUtil.fdec6.format(data.hoverExpectedDrop)
+                    + " hoverActualDrop=" + StringUtil.fdec6.format(data.hoverActualDrop)
+                    + " hoverLastYVelocity=" + StringUtil.fdec6.format(data.hoverLastYVelocity)
+                    + " hoverDropDeficit=" + StringUtil.fdec6.format(deficit));
         }
         // Delegate violation handling.
         survivalFly.handleHoverViolation(player, loc, cc, data);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/location/tracking/LocationTrace.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/location/tracking/LocationTrace.java
@@ -144,6 +144,16 @@ public class LocationTrace {
         }
 
         @Override
+        public synchronized TraceEntry getInstance() {
+            return super.getInstance();
+        }
+
+        @Override
+        public synchronized void returnInstance(final TraceEntry instance) {
+            super.returnInstance(instance);
+        }
+
+        @Override
         protected TraceEntry newInstance() {
             return new TraceEntry();
         }
@@ -256,7 +266,10 @@ public class LocationTrace {
             }
         }
         // Add a new entry.
-        final TraceEntry newEntry = pool.getInstance();
+        final TraceEntry newEntry = pool == null ? new TraceEntry() : pool.getInstance();
+        if (newEntry == null) {
+            return;
+        }
         newEntry.set(time, x, y, z, boxMarginHorizontal, boxMarginVertical);
         setFirst(newEntry);
         // Remove the last entry, if maxSize is exceeded.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/model/PlayerMoveData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/model/PlayerMoveData.java
@@ -76,7 +76,7 @@ public class PlayerMoveData extends MoveData {
      * riptide action itself.
      * 
      */
-    public AlmostBoolean tridentRelease;
+    public AlmostBoolean tridentRelease = AlmostBoolean.NO;
     
     /**
      * The distance covered by a move from the setback point to the to.getY() point.
@@ -271,7 +271,7 @@ public class PlayerMoveData extends MoveData {
      *
      * <p>For clients supporting impulse event-sending, this will only return YES or NO, as input data is always available.</p>
      */
-    public AlmostBoolean hasImpulse;
+    public AlmostBoolean hasImpulse = AlmostBoolean.NO;
     
     /**
      * Indicates the strafing direction (LEFT, RIGHT, or NONE).
@@ -279,7 +279,7 @@ public class PlayerMoveData extends MoveData {
      * <p>This value is set even if horizontal movement could not be accurately predicted, so it may be unreliable, unless the client sends impulse events, in which case it is dependable.
      * Check {@link PlayerMoveData#hasImpulse} for its reliability prior to version 1.21.2 </p>
      */
-    public PlayerKeyboardInput.StrafeDirection strafeImpulse;
+    public PlayerKeyboardInput.StrafeDirection strafeImpulse = PlayerKeyboardInput.StrafeDirection.NONE;
     
     /**
      * Indicates the forward movement direction (FORWARD, BACKWARD, or NONE).
@@ -287,7 +287,7 @@ public class PlayerMoveData extends MoveData {
      * <p>This value is set even if horizontal movement could not be accurately predicted, so it may be unreliable, unless the client sends impulse events, in which case it is dependable.
      * Check {@link PlayerMoveData#hasImpulse} for its reliability prior to version 1.21.2 </p>
      */
-    public PlayerKeyboardInput.ForwardDirection forwardImpulse;
+    public PlayerKeyboardInput.ForwardDirection forwardImpulse = PlayerKeyboardInput.ForwardDirection.NONE;
     
     /**
      * Judge if this horizontal collision ({@link PlayerMoveData#collideX} or {@link PlayerMoveData#collideZ}) is to be considered as minor.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/NoFall.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/NoFall.java
@@ -429,15 +429,15 @@ public class NoFall extends Check {
                             if (player.getNoDamageTicks() > 0) {
                                 return;
                             }
-                            player.setLastDamageCause(event);
+                            BridgeHealth.setLastDamageCause(player, event);
                             mcAccess.getHandle().dealFallDamage(player, BridgeHealth.getRawDamage(event));
                             TickTask.removeTickListener(this);
                         }
                     };
                     TickTask.addTickListener(damagePlayer);
-                } 
+                }
                 else {
-                    player.setLastDamageCause(event);
+                    BridgeHealth.setLastDamageCause(player, event);
                     mcAccess.getHandle().dealFallDamage(player, BridgeHealth.getRawDamage(event));
                 }
             }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/Passable.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/Passable.java
@@ -29,6 +29,8 @@ import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
 import fr.neatmonster.nocheatplus.checks.moving.MovingData;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.collision.Axis;
 import fr.neatmonster.nocheatplus.utilities.collision.tracing.axis.ICollidePassable;
 import fr.neatmonster.nocheatplus.utilities.collision.tracing.axis.PassableAxisTracing;
@@ -90,6 +92,7 @@ public class Passable extends Check {
         rayTracing.setAxisOrder(Axis.AXIS_ORDER_YXZ);
         String newTag = checkRayTracing(player, from, to, manhattan, data, cc, debug, tick, useBlockChangeTracker);
         if (newTag != null) {
+            // Diagnostic info: alternate axis orders identify which collision path caused a passable flag.
             newTag = checkRayTracingAlernateOrder(player, from, to, manhattan, debug, data, cc, tick, useBlockChangeTracker, newTag);
         }
         // Finally handle violations.
@@ -215,13 +218,18 @@ public class Passable extends Check {
         // Return the reset position.
         data.passableVL += 1d;
         final ViolationData vd = new ViolationData(this, player, data.passableVL, 1, cc.passableActions);
+        // Diagnostic info: keep raytrace branch/block context on MOVING_PASSABLE violations.
+        final String diagnosticTags = getPassableTags(tags, from, to);
         if (debug || vd.needsParameters()) {
             vd.setParameter(ParameterName.LOCATION_FROM, String.format(Locale.US, "%.2f, %.2f, %.2f", from.getX(), from.getY(), from.getZ()));
             vd.setParameter(ParameterName.LOCATION_TO, String.format(Locale.US, "%.2f, %.2f, %.2f", to.getX(), to.getY(), to.getZ()));
             vd.setParameter(ParameterName.DISTANCE, String.format(Locale.US, "%.2f", TrigUtil.distance(from, to)));
-            if (!tags.isEmpty()) {
-                vd.setParameter(ParameterName.TAGS, tags);
+            if (!diagnosticTags.isEmpty()) {
+                vd.setParameter(ParameterName.TAGS, diagnosticTags);
             }
+        }
+        if (CheckUtils.shouldLogDebugToConsole()) {
+            logPassableDetail(player, from, to, data.passableVL, diagnosticTags);
         }
         if (executeActions(vd).willCancel()) {
             // TODO: Consider another set back position for this, also keeping track of players moving around in blocks.
@@ -245,9 +253,53 @@ public class Passable extends Check {
         }
     }
 
+    private String getPassableTags(final String tags, final PlayerLocation from, final PlayerLocation to) {
+        // Diagnostic info: show which passable raytrace branch failed and which blocks were involved.
+        final String branch = tags == null || tags.isEmpty() ? "unknown" : tags.replaceAll("_+$", "");
+        return "subcheck_passable_raytrace"
+                + "+branch_" + branch.toLowerCase(Locale.ROOT)
+                + "+from_block_" + from.getBlockType().name().toLowerCase(Locale.ROOT)
+                + "+to_block_" + to.getBlockType().name().toLowerCase(Locale.ROOT);
+    }
+
+    private void logPassableDetail(final Player player, final PlayerLocation from, final PlayerLocation to,
+                                   final double totalVL, final String tags) {
+        try {
+            // Diagnostic info: console-only passable context for stuck-on-block and collision false positives.
+            player.getServer().getLogger().info(new StringBuilder(420)
+                    .append("[NCP][Passable][detail] player=").append(player.getName())
+                    .append(" uuid=").append(player.getUniqueId())
+                    .append(" subcheck=PASSABLE_RAYTRACE")
+                    .append(" summary=passable_raytrace{branch=").append(tags == null ? "unknown" : tags)
+                    .append(",from=").append(from.getBlockType())
+                    .append(",to=").append(to.getBlockType())
+                    .append(",vl=").append(StringUtil.fdec3.format(totalVL))
+                    .append('}')
+                    .append(" totalVL=").append(StringUtil.fdec3.format(totalVL))
+                    .append(" distance=").append(StringUtil.fdec3.format(TrigUtil.distance(from, to)))
+                    .append(" from=").append(formatLocation(from))
+                    .append(" to=").append(formatLocation(to))
+                    .append(" fromBlock=").append(from.getBlockType())
+                    .append(" toBlock=").append(to.getBlockType())
+                    .append(" fromPassable=").append(from.isPassable())
+                    .append(" toPassable=").append(to.isPassable())
+                    .append(" tags=").append(tags)
+                    .toString());
+        }
+        catch (Throwable ignored) {}
+    }
+
+    private String formatLocation(final PlayerLocation location) {
+        return StringUtil.fdec3.format(location.getX())
+                + "," + StringUtil.fdec3.format(location.getY())
+                + "," + StringUtil.fdec3.format(location.getZ())
+                + "/" + StringUtil.fdec3.format(location.getYaw())
+                + "," + StringUtil.fdec3.format(location.getPitch());
+    }
+
     /**
      * Debug only if colliding.
-     * 
+     *
      * @param player
      * @param rayTracing
      * @param tag

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleEnvelope.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleEnvelope.java
@@ -25,6 +25,7 @@ import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Pig;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
 
 import fr.neatmonster.nocheatplus.actions.ParameterName;
 import fr.neatmonster.nocheatplus.checks.Check;
@@ -35,6 +36,7 @@ import fr.neatmonster.nocheatplus.checks.moving.MovingData;
 import fr.neatmonster.nocheatplus.checks.moving.envelope.workaround.LostGroundVehicle;
 import fr.neatmonster.nocheatplus.checks.moving.envelope.workaround.VehicleWorkarounds;
 import fr.neatmonster.nocheatplus.checks.moving.location.setback.SetBackEntry;
+import fr.neatmonster.nocheatplus.checks.moving.model.LocationData;
 import fr.neatmonster.nocheatplus.checks.moving.model.PlayerMoveData;
 import fr.neatmonster.nocheatplus.checks.moving.model.VehicleMoveData;
 import fr.neatmonster.nocheatplus.checks.moving.model.VehicleMoveInfo;
@@ -42,6 +44,7 @@ import fr.neatmonster.nocheatplus.checks.workaround.WRPT;
 import fr.neatmonster.nocheatplus.compat.Bridge1_13;
 import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.entity.PotionUtil;
@@ -159,6 +162,9 @@ public class VehicleEnvelope extends Check {
 
         if (violation) {
             data.vehicleEnvelopeVL += 1.0; // Add up one for now.
+            if (CheckUtils.shouldLogDebugToConsole()) {
+                logConsoleDetails(player, vehicle, thisMove, isFake, data, cc, moveInfo);
+            }
             final ViolationData vd = new ViolationData(this, player, data.vehicleEnvelopeVL, 1, cc.vehicleEnvelopeActions);
             vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));
             if (executeActions(vd).willCancel()) {
@@ -170,6 +176,91 @@ public class VehicleEnvelope extends Check {
             // Do not set a set back here.
         }
         return null;
+    }
+
+    private void logConsoleDetails(final Player player, final Entity vehicle,
+                                   final VehicleMoveData thisMove, final boolean isFake,
+                                   final MovingData data, final MovingConfig cc,
+                                   final VehicleMoveInfo moveInfo) {
+        final StringBuilder builder = new StringBuilder(800);
+        builder.append("[NCP][VehicleEnvelope][detail]")
+                .append(" player=").append(player.getName())
+                .append(" uuid=").append(player.getUniqueId())
+                .append(" vehicle=").append(vehicle.getType())
+                .append(" vehicleId=").append(vehicle.getUniqueId())
+                .append(" fake=").append(isFake)
+                .append(" addVL=1")
+                .append(" totalVL=").append(StringUtil.fdec3.format(data.vehicleEnvelopeVL))
+                .append(" tags=").append(StringUtil.join(tags, "+"))
+                .append(" move=h:").append(StringUtil.fdec6.format(thisMove.hDistance))
+                .append(",x:").append(StringUtil.fdec6.format(thisMove.xDistance))
+                .append(",y:").append(StringUtil.fdec6.format(thisMove.yDistance))
+                .append(",z:").append(StringUtil.fdec6.format(thisMove.zDistance))
+                .append(",distSq:").append(StringUtil.fdec6.format(thisMove.distanceSquared))
+                .append(" from=").append(formatLocation(thisMove.from))
+                .append(" to=").append(formatLocation(thisMove.to))
+                .append(" fromEnv=").append(formatEnvironment(thisMove.from))
+                .append(" toEnv=").append(formatEnvironment(thisMove.to))
+                .append(" details=simplified:").append(checkDetails.simplifiedType)
+                .append(",inAir:").append(checkDetails.inAir)
+                .append(",fromSafe:").append(checkDetails.fromIsSafeMedium)
+                .append(",toSafe:").append(checkDetails.toIsSafeMedium)
+                .append(",canClimb:").append(checkDetails.canClimb)
+                .append(",canRails:").append(checkDetails.canRails)
+                .append(",canJump:").append(checkDetails.canJump)
+                .append(",canStep:").append(checkDetails.canStepUpBlock)
+                .append(",maxAscend:").append(StringUtil.fdec6.format(checkDetails.maxAscend))
+                .append(",gravityTarget:").append(StringUtil.fdec6.format(checkDetails.gravityTargetSpeed))
+                .append(",checkAscend:").append(checkDetails.checkAscendMuch)
+                .append(",checkDescend:").append(checkDetails.checkDescendMuch)
+                .append(" playerState=vehicle:").append(player.isInsideVehicle())
+                .append(",sneak:").append(player.isSneaking())
+                .append(",sprint:").append(player.isSprinting())
+                .append(",fly:").append(player.isFlying())
+                .append(",allowFlight:").append(player.getAllowFlight())
+                .append(" velocity=player:").append(formatVector(player.getVelocity()))
+                .append(",vehicle:").append(formatVector(vehicle.getVelocity()))
+                .append(" vehicleState=valid:").append(vehicle.isValid())
+                .append(",dead:").append(vehicle.isDead())
+                .append(",onGround:").append(vehicle.isOnGround())
+                .append(" moveInfo=fromFlags:").append(moveInfo.from.getBlockFlags())
+                .append(",toFlags:").append(moveInfo.to.getBlockFlags())
+                .append(" config=vehicleEnvelopeVL:").append(StringUtil.fdec3.format(data.vehicleEnvelopeVL))
+                .append(",boatIceTicks:").append(data.boatIceVelocityTicks)
+                .append(",actions:").append(cc.vehicleEnvelopeActions);
+        // Diagnostic logging: mirror vehicle details to console so boat false positives can be matched to exact terrain.
+        player.getServer().getLogger().info(builder.toString());
+    }
+
+    private String formatLocation(final LocationData location) {
+        return location.getWorldName()
+                + "@" + StringUtil.fdec3.format(location.getX())
+                + "," + StringUtil.fdec3.format(location.getY())
+                + "," + StringUtil.fdec3.format(location.getZ());
+    }
+
+    private String formatEnvironment(final LocationData location) {
+        return "{ground:" + location.onGround
+                + ",reset:" + location.resetCond
+                + ",water:" + location.inWater
+                + ",lava:" + location.inLava
+                + ",liquid:" + location.inLiquid
+                + ",climb:" + location.onClimbable
+                + ",web:" + location.inWeb
+                + ",ice:" + location.onIce
+                + ",blueIce:" + location.onBlueIce
+                + ",slime:" + location.onSlimeBlock
+                + ",honey:" + location.onHoneyBlock
+                + ",bubble:" + location.inBubbleStream
+                + ",soulSand:" + location.onSoulSand
+                + ",valid:" + location.extraPropertiesValid
+                + "}";
+    }
+
+    private String formatVector(final Vector vector) {
+        return StringUtil.fdec6.format(vector.getX())
+                + "," + StringUtil.fdec6.format(vector.getY())
+                + "," + StringUtil.fdec6.format(vector.getZ());
     }
 
 
@@ -258,7 +349,8 @@ public class VehicleEnvelope extends Check {
 
         if ((thisMove.from.onGround && !thisMove.from.inWater) 
             || thisMove.to.onGround && !thisMove.to.inWater) {
-            return multiplier * 0.4;
+            // False-positive tuning: boats crossing shore/ground blocks on Folia can exceed the old 0.4 cap.
+            return multiplier * 0.75;
         }
 
         if (thisMove.from.inWater || thisMove.to.inWater) {
@@ -662,7 +754,8 @@ public class VehicleEnvelope extends Check {
         if (data.sfJumpPhase > (checkDetails.canJump ? MagicVehicle.maxJumpPhaseAscend : 1)
             && thisMove.yDistance > Math.max(minDescend, -checkDetails.gravityTargetSpeed)) {
             
-            boolean noViolation = collidesWithHoneyBlock(from) 
+            boolean noViolation = collidesWithHoneyBlock(from)
+                    || isBoatDownhillMove(thisMove)
                     || (vehicle instanceof LivingEntity && !Double.isInfinite(Bridge1_13.getSlowfallingAmplifier((LivingEntity)vehicle)))
                     || !vehicle.hasGravity();
             // TODO: What is this? Vehicle slide on honey block?
@@ -691,6 +784,15 @@ public class VehicleEnvelope extends Check {
             }
         }
         return violation;
+    }
+
+    private boolean isBoatDownhillMove(final VehicleMoveData thisMove) {
+        return MaterialUtil.isBoat(checkDetails.simplifiedType)
+                && thisMove.yDistance <= 0.0
+                && thisMove.yDistance >= -0.8
+                && thisMove.hDistance <= 0.8
+                && !thisMove.from.inWater
+                && !thisMove.to.inWater;
     }
 
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/velocity/PairAxisVelocity.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/velocity/PairAxisVelocity.java
@@ -164,6 +164,88 @@ public class PairAxisVelocity {
     }
 
     /**
+     * Use the next velocity entry that can cover the demanded x/z displacement.
+     * This is meant for knockback-style compensation, where the player may only
+     * consume part of a queued velocity vector during one move.
+     */
+    public List<PairEntry> useCovering(final double x, final double z, final int minActCount,
+                                       final int maxActCount, final double tolerance) {
+        final List<PairEntry> available = peekCovering(x, z, minActCount, maxActCount, tolerance);
+        if (available.isEmpty()) {
+            return available;
+        }
+        return use(available.get(0).tick);
+    }
+
+    public List<PairEntry> peekCovering(final double x, final double z, final int minActCount,
+                                        final int maxActCount, final double tolerance) {
+        final List<PairEntry> result = new LinkedList<>();
+        double totalAmountX = 0;
+        double totalAmountZ = 0;
+        int lastTick = 0;
+        boolean hasVel = false;
+        final Iterator<PairEntry> it = queued.iterator();
+        while (it.hasNext()) {
+            final PairEntry entry = it.next();
+            if (entry.actCount < minActCount || entry.actCount > maxActCount) {
+                continue;
+            }
+            if ((entry.flags & VelocityFlags.ADDITIVE) != 0 && lastTick == entry.tick) {
+                totalAmountX += entry.x;
+                totalAmountZ += entry.z;
+                result.add(entry);
+                hasVel = true;
+            }
+            else {
+                if (hasVel && coversVector(totalAmountX, totalAmountZ, x, z, tolerance)) {
+                    return result;
+                }
+                result.clear();
+                totalAmountX = entry.x;
+                totalAmountZ = entry.z;
+                lastTick = entry.tick;
+                result.add(entry);
+                hasVel = true;
+            }
+        }
+        if (hasVel && coversVector(totalAmountX, totalAmountZ, x, z, tolerance)) {
+            return result;
+        }
+        result.clear();
+        return result;
+    }
+
+    private boolean covers(final double velocity, final double amount, final double tolerance) {
+        return Math.abs(amount) <= tolerance
+                || Math.signum(velocity) == Math.signum(amount)
+                && Math.abs(amount) <= Math.abs(velocity) + tolerance;
+    }
+
+    private boolean coversVector(final double velocityX, final double velocityZ,
+                                 final double amountX, final double amountZ,
+                                 final double tolerance) {
+        final double amountSq = amountX * amountX + amountZ * amountZ;
+        if (amountSq <= tolerance * tolerance) {
+            return true;
+        }
+        final double velocitySq = velocityX * velocityX + velocityZ * velocityZ;
+        if (velocitySq <= tolerance * tolerance) {
+            return false;
+        }
+        final double dot = velocityX * amountX + velocityZ * amountZ;
+        if (dot < -tolerance) {
+            return false;
+        }
+        final double amount = Math.sqrt(amountSq);
+        final double velocity = Math.sqrt(velocitySq);
+        if (amount > velocity + tolerance) {
+            return false;
+        }
+        final double perpendicular = Math.abs(velocityX * amountZ - velocityZ * amountX) / velocity;
+        return perpendicular <= Math.max(tolerance, 0.02);
+    }
+
+    /**
      * Without checking for invalidation, test if there is a matching entry with
      * same or less the activation count.
      * 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveDiagnostics.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveDiagnostics.java
@@ -1,0 +1,81 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.checks.net;
+
+import org.bukkit.entity.Player;
+
+import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
+import fr.neatmonster.nocheatplus.utilities.TickTask;
+
+/**
+ * Console-only formatting for KeepAliveFrequency diagnostics.
+ */
+final class KeepAliveDiagnostics {
+
+    private KeepAliveDiagnostics() {}
+
+    static String formatDetail(final Player player, final long packetTime, final long now, final long joinTime,
+                               final NetData data, final NetConfig cc, final IPlayerData pData,
+                               final float first, final float fullScore, final double vl,
+                               final boolean cancel, final String model, final float firstLimit) {
+        final long bucketDuration = data.keepAliveFreq.bucketDuration();
+        final int buckets = data.keepAliveFreq.numberOfBuckets();
+        return new StringBuilder(900)
+                .append("[NCP][KeepAliveFrequency][detail] player=").append(player.getName())
+                .append(" uuid=").append(player.getUniqueId())
+                .append(" client=").append(pData.getClientVersion())
+                .append(" summary=keepalive_bucket{first=").append(StringUtil.fdec3.format(first))
+                .append(",full=").append(StringUtil.fdec3.format(fullScore))
+                .append(",expected=").append(data.keepAliveFreq.numberOfBuckets())
+                .append(",cancel=").append(cancel)
+                .append('}')
+                .append(" packetTime=").append(packetTime)
+                .append(" now=").append(now)
+                .append(" joinAge=").append(joinTime <= 0L ? -1L : now - joinTime)
+                .append(" startupDelay=").append(cc.keepAliveFrequencyStartupDelay)
+                .append(" vl=").append(StringUtil.fdec3.format(vl))
+                .append(" cancel=").append(cancel)
+                .append(" model=").append(model)
+                .append(" firstLimit=").append(StringUtil.fdec3.format(firstLimit))
+                .append(" firstBucket=").append(StringUtil.fdec3.format(first))
+                .append(" fullScore=").append(StringUtil.fdec3.format(fullScore))
+                .append(" expectedFull=").append(buckets)
+                .append(" bucketDuration=").append(bucketDuration)
+                .append(" bucketAge=").append(now - data.keepAliveFreq.lastAccess())
+                .append(" lastUpdateAge=").append(now - data.keepAliveFreq.lastUpdate())
+                .append(" lag1s=").append(StringUtil.fdec3.format(TickTask.getLag(bucketDuration, true)))
+                .append(" lagWindow=").append(StringUtil.fdec3.format(TickTask.getLag(bucketDuration * buckets, true)))
+                .append(" buckets=").append(formatBuckets(data, Math.min(6, buckets)))
+                .append(" state=").append(data.describeKeepAliveState(now))
+                .toString();
+    }
+
+    private static String formatBuckets(final NetData data, final int limit) {
+        final StringBuilder builder = new StringBuilder(80);
+        builder.append('[');
+        for (int i = 0; i < limit; i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append(StringUtil.fdec3.format(data.keepAliveFreq.bucketScore(i)));
+        }
+        if (limit < data.keepAliveFreq.numberOfBuckets()) {
+            builder.append(",...");
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveFrequency.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveFrequency.java
@@ -19,6 +19,7 @@ import org.bukkit.entity.Player;
 import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
 
 public class KeepAliveFrequency extends Check {
 
@@ -35,21 +36,95 @@ public class KeepAliveFrequency extends Check {
      * @return If to cancel.
      */
     public boolean check(final Player player, final long time, final NetData data, final NetConfig cc, final IPlayerData pData) {
-        data.keepAliveFreq.add(time, 1f);
-        final float first = data.keepAliveFreq.bucketScore(0);
         final long now = System.currentTimeMillis();
-        
-        if (now > pData.getLastJoinTime() && pData.getLastJoinTime() + cc.keepAliveFrequencyStartupDelay * 1000 < now) {
+        final long joinTime = pData.getLastJoinTime();
+        if (joinTime > 0L && now < joinTime + cc.keepAliveFrequencyStartupDelay) {
             return false;
         }
+        if (data.keepAliveExpectedResponse && !data.keepAliveDuplicateId) {
+            return false;
+        }
+        data.keepAliveFreq.add(time, 1f);
+        final float first = data.keepAliveFreq.bucketScore(0);
         
         if (first > 1f) {
             // Trigger a violation.
-            final double vl = Math.max(first - 1f, data.keepAliveFreq.score(1f) - data.keepAliveFreq.numberOfBuckets());
-            if (executeActions(player, vl, 1.0, cc.keepAliveFrequencyActions).willCancel()) {
-                return true;
+            final float fullScore = data.keepAliveFreq.score(1f);
+            if (isModeledBoundaryBurst(data, fullScore, first)) {
+                return false;
             }
+            final double vl = Math.max(first - getFirstBucketViolationLimit(data), fullScore - data.keepAliveFreq.numberOfBuckets());
+            final boolean cancel = executeActions(player, vl, 1.0, cc.keepAliveFrequencyActions).willCancel();
+            if (CheckUtils.shouldLogDebugToConsole()) {
+                // Diagnostic info: bucket details separate duplicate packets from normal boundary timing.
+                logConsoleDetails(player, time, now, joinTime, data, cc, pData, first, fullScore, vl,
+                        cancel, describeKeepAliveModel(data, fullScore, first), getFirstBucketViolationLimit(data));
+            }
+            return cancel;
         }
         return false;
+    }
+
+    private boolean isModeledBoundaryBurst(final NetData data, final float fullScore, final float first) {
+        // KeepAlive model: if outgoing tracking is unavailable, only treat small monotonic id bursts as timing leftovers.
+        if (data.keepAliveDuplicateId || fullScore > data.keepAliveFreq.numberOfBuckets() + 2f) {
+            return false;
+        }
+        // Folia/netty can timestamp two adjacent valid replies in the same millisecond; do not cancel a single pair.
+        return first <= 2f || isUntrackedMonotonicBurst(data, fullScore, first);
+    }
+
+    private boolean isUntrackedMonotonicBurst(final NetData data, final float fullScore, final float first) {
+        if (data.keepAliveOutgoingSeen || fullScore > data.keepAliveFreq.numberOfBuckets()) {
+            return false;
+        }
+        if (!data.keepAlivePacketIdAvailable || !data.keepAlivePreviousPacketIdAvailable) {
+            return false;
+        }
+        if (data.keepAlivePacketId <= data.keepAlivePreviousPacketId) {
+            return false;
+        }
+        return first <= getFallbackFirstBucketLimit(data);
+    }
+
+    private float getFirstBucketViolationLimit(final NetData data) {
+        if (data.keepAliveDuplicateId) {
+            return 1f;
+        }
+        if (!data.keepAliveOutgoingSeen
+                && data.keepAlivePacketIdAvailable
+                && data.keepAlivePreviousPacketIdAvailable
+                && data.keepAlivePacketId > data.keepAlivePreviousPacketId) {
+            return getFallbackFirstBucketLimit(data);
+        }
+        return 2f;
+    }
+
+    private float getFallbackFirstBucketLimit(final NetData data) {
+        return Math.max(3f, Math.min(6f, data.keepAliveFreq.numberOfBuckets() / 4f));
+    }
+
+    private String describeKeepAliveModel(final NetData data, final float fullScore, final float first) {
+        if (data.keepAliveDuplicateId) {
+            return "duplicate-id";
+        }
+        if (data.keepAliveOutgoingSeen) {
+            return "unmatched-outgoing";
+        }
+        if (isUntrackedMonotonicBurst(data, fullScore, first)) {
+            return "untracked-monotonic-burst";
+        }
+        return "bucket-frequency";
+    }
+
+    private void logConsoleDetails(final Player player, final long packetTime, final long now, final long joinTime,
+                                   final NetData data, final NetConfig cc, final IPlayerData pData,
+                                   final float first, final float fullScore, final double vl,
+                                   final boolean cancel, final String model, final float firstLimit) {
+        try {
+            player.getServer().getLogger().info(KeepAliveDiagnostics.formatDetail(player, packetTime, now, joinTime,
+                    data, cc, pData, first, fullScore, vl, cancel, model, firstLimit));
+        }
+        catch (Throwable ignored) {}
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/Moving.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/Moving.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.util.Vector;
 
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.actions.ParameterName;
@@ -27,7 +28,11 @@ import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.checks.ViolationData;
 import fr.neatmonster.nocheatplus.checks.moving.MovingData;
+import fr.neatmonster.nocheatplus.checks.moving.model.LocationData;
+import fr.neatmonster.nocheatplus.checks.moving.model.PlayerKeyboardInput;
+import fr.neatmonster.nocheatplus.checks.moving.model.PlayerMoveData;
 import fr.neatmonster.nocheatplus.checks.net.model.DataPacketFlying;
+import fr.neatmonster.nocheatplus.checks.net.model.DataPacketInput;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.CheckUtils;
@@ -41,10 +46,6 @@ import fr.neatmonster.nocheatplus.utilities.math.TrigUtil;
  */
 public class Moving extends Check {
 
-    /** For temporary use: LocUtil.clone before passing deeply, call setWorld(null) after use. */
-    final Location useLoc = new Location(null, 0, 0, 0);
-    final List<String> tags = new ArrayList<String>();
-    
     public Moving() {
         super(CheckType.NET_MOVING);
     }
@@ -67,27 +68,114 @@ public class Moving extends Check {
         boolean cancel = false;
         final long now = System.currentTimeMillis();
         final boolean debug = pData.isDebugActive(CheckType.NET_MOVING);
-        tags.clear();
+        final List<String> tags = new ArrayList<String>();
         if (now > pData.getLastJoinTime() && pData.getLastJoinTime() + 10000 > now) {
             tags.add("login_grace");
         	return false;
         }
+        if (player.isDead()) {
+            tags.add("dead_grace");
+            data.movingVL *= 0.5;
+            return false;
+        }
         if (packetData != null && packetData.hasPos) {
             final MovingData mData = pData.getGenericInstance(MovingData.class);
             /** Actual Location on the server */
-            final Location knownLocation = player.getLocation(useLoc);
+            final Location useLoc = new Location(null, 0, 0, 0);
+            final Location rawKnownLocation = player.getLocation(useLoc);
+            if (rawKnownLocation == null || rawKnownLocation.getWorld() == null) {
+                // Folia compatibility: a disconnecting player can leave the temporary Location without a world.
+                tags.add("known_world_null_grace");
+                useLoc.setWorld(null);
+                return false;
+            }
+            // Folia/packet safety: keep packet-thread teleport models away from mutable temporary Location state.
+            final Location knownLocation = LocUtil.clone(rawKnownLocation);
+            useLoc.setWorld(null);
+            data.recordMovingKnownLocation(knownLocation, now);
             /** Claimed Location sent by the client */
             final Location packetLocation = new Location(null, packetData.getX(), packetData.getY(), packetData.getZ());
             //final double distanceSq = TrigUtil.distanceSquared(knownLocation, packetLocation);
             final double yDistance = Math.abs(knownLocation.getY() - packetLocation.getY());
             final double hDistance = TrigUtil.xzDistance(knownLocation, packetLocation);
             final double distance = TrigUtil.distance(knownLocation, packetLocation);
+            final boolean extremeMove = yDistance > 100.0 || distance > 100.0;
+
+            final boolean teleportGrace = data.isWithinMovingTeleportGrace(now);
+            final boolean outgoingPositionGrace = data.isWithinOutgoingPositionGrace(now, knownLocation);
+            final boolean serverPositionJumpModel = data.isWithinServerPositionJumpStalePacketModel(now,
+                    knownLocation, packetLocation, packetData);
+            final boolean teleportCommandModel = data.isWithinTeleportCommandStalePacketModel(now,
+                    knownLocation, packetLocation, packetData);
+            final boolean teleportResyncStalePacketDropModel = (serverPositionJumpModel || teleportCommandModel)
+                    && data.isWithinTeleportResyncStalePacketDropModel(now, knownLocation, packetLocation, packetData);
+            final boolean expectedOutgoingPositionGrace = extremeMove && data.consumeExpectedOutgoingPosition(packetData);
+            final boolean serverPositionJumpRecoveryGrace = extremeMove
+                    && !serverPositionJumpModel
+                    && !teleportCommandModel
+                    && isServerPositionJumpRecoveryContext(mData)
+                    && data.consumeServerPositionJumpRecoveryGrace(now, knownLocation);
+            // NetMoving compatibility: match extreme packets against teleport/server-position history before flagging.
+            if (extremeMove && (teleportGrace || outgoingPositionGrace || expectedOutgoingPositionGrace
+                    || serverPositionJumpModel || serverPositionJumpRecoveryGrace || teleportCommandModel)) {
+                if (teleportGrace) {
+                    tags.add("teleport_grace");
+                }
+                if (outgoingPositionGrace) {
+                    tags.add("outgoing_position_grace");
+                }
+                if (expectedOutgoingPositionGrace) {
+                    tags.add("expected_outgoing_position_grace");
+                }
+                if (serverPositionJumpModel) {
+                    tags.add("server_position_jump_stale_packet_model");
+                }
+                if (serverPositionJumpRecoveryGrace) {
+                    tags.add("server_position_jump_recovery_grace");
+                }
+                if (teleportCommandModel) {
+                    tags.add("teleport_command_stale_packet_model");
+                }
+                if (serverPositionJumpModel || teleportCommandModel) {
+                    tags.add("teleport_resync_history_reset");
+                }
+                if (teleportResyncStalePacketDropModel) {
+                    tags.add("teleport_resync_stale_packet_drop");
+                }
+                if (CheckUtils.shouldLogDebugToConsole()
+                        && !(serverPositionJumpModel || teleportCommandModel)) {
+                    final String reason = serverPositionJumpModel || teleportCommandModel ? "model" : "grace";
+                    logConsoleDetails(reason, tags, player, packetData, knownLocation, packetLocation, hDistance, yDistance,
+                            distance, data, mData, pData, now);
+                }
+                if (serverPositionJumpModel || teleportCommandModel) {
+                    final String reason = serverPositionJumpModel ? "server_position_jump_stale_packet_model"
+                            : "teleport_command_stale_packet_model";
+                    // Teleport model: accepted stale packets are deleted from packet history, not kept as movement data.
+                    if (teleportResyncStalePacketDropModel) {
+                        data.acceptMovingTeleportStalePacketContinuation(player, knownLocation, packetLocation,
+                                packetData, now, reason);
+                    }
+                    else {
+                        data.acceptMovingTeleportResync(player, plugin, mData, knownLocation, packetLocation,
+                                packetData, now, reason);
+                    }
+                }
+                data.movingVL *= 0.98;
+                return false;
+            }
 
             // 100 it's the minimum [Math.max(100, config distance)]distance for the 'moved too quickly' check to fire
             // See PlayerConnection.java
-            if (yDistance > 100.0 || distance > 100.0/*distanceSq > 100.0 || hDistance > 100.0*/) {
+            if (extremeMove/*distanceSq > 100.0 || hDistance > 100.0*/) {
                 data.movingVL++ ;
                 tags.add("invalid_pos");
+                // Diagnostic info: separate net extreme-move flags from teleport/grace branches.
+                tags.add(0, "subcheck_netmoving_extreme_move");
+                if (CheckUtils.shouldLogDebugToConsole()) {
+                    logConsoleDetails("violation", tags, player, packetData, knownLocation, packetLocation, hDistance, yDistance,
+                            distance, data, mData, pData, now);
+                }
                 final ViolationData vd = new ViolationData(this, player, data.movingVL, 1.0, cc.movingActions);
                 if (vd.needsParameters()) vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));
                 cancel = executeActions(vd).willCancel();
@@ -98,20 +186,341 @@ public class Moving extends Check {
         }
 
         if (debug) {
-            final Location packetLocation = new Location(null, packetData.getX(), packetData.getY(), packetData.getZ());
             final StringBuilder builder = new StringBuilder(500);
-            if (packetData.hasPos) {
+            if (packetData != null && packetData.hasPos) {
+                final Location packetLocation = new Location(null, packetData.getX(), packetData.getY(), packetData.getZ());
+                final Location serverLocation = player.getLocation();
                 builder.append(CheckUtils.getLogMessagePrefix(player, type));
                 builder.append("\nPacket location: " + LocUtil.simpleFormat(packetLocation));
-                builder.append("\nServer location: " + LocUtil.simpleFormat(player.getLocation(useLoc)));
-                builder.append("\nDeltas: h= " + TrigUtil.distance(player.getLocation(useLoc), packetLocation) + ", y= " + Math.abs(player.getLocation(useLoc).getY() - packetLocation.getY()));
+                builder.append("\nServer location: " + LocUtil.simpleFormat(serverLocation));
+                builder.append("\nDeltas: h= " + TrigUtil.distance(serverLocation, packetLocation) + ", y= " + Math.abs(serverLocation.getY() - packetLocation.getY()));
             }
             else {
             	builder.append("Empty packet (no position)");
             }
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().debug(Streams.TRACE_FILE, builder.toString());
         }
-        useLoc.setWorld(null);
         return cancel;
+    }
+
+    private boolean isServerPositionJumpRecoveryContext(final MovingData data) {
+        // False-positive tuning: death/respawn and portal/server jumps can leave move history invalid for one packet.
+        final PlayerMoveData currentMove = data.playerMoves.getCurrentMove();
+        final PlayerMoveData lastMove = data.playerMoves.getFirstPastMove();
+        return data.joinOrRespawn
+                || !data.hasSetBack()
+                || !currentMove.toIsValid
+                || !lastMove.toIsValid;
+    }
+
+    private void logConsoleDetails(final String reason, final List<String> tags,
+                                   final Player player, final DataPacketFlying packetData,
+                                   final Location knownLocation, final Location packetLocation,
+                                   final double hDistance, final double yDistance, final double distance,
+                                   final NetData data, final MovingData mData, final IPlayerData pData,
+                                   final long now) {
+        try {
+            final String joinedTags = StringUtil.join(tags, "+");
+            player.getServer().getLogger().info(new StringBuilder(700)
+                    .append("[NCP][NetMoving][detail] player=").append(player.getName())
+                    .append(" reason=").append(reason)
+                    .append(" subcheck=").append("violation".equals(reason) ? "NETMOVING_EXTREME_MOVE"
+                            : "model".equals(reason) ? "NETMOVING_TELEPORT_RESYNC_MODEL" : "NETMOVING_GRACE")
+                    .append(" summary=net_moving{reason=").append(reason)
+                    .append(",h=").append(StringUtil.fdec3.format(hDistance))
+                    .append(",y=").append(StringUtil.fdec3.format(yDistance))
+                    .append(",total=").append(StringUtil.fdec3.format(distance))
+                    .append(",tags=").append(joinedTags.isEmpty() ? "none" : joinedTags)
+                    .append('}')
+                    .append(" uuid=").append(player.getUniqueId())
+                    .append(" client=").append(pData.getClientVersion())
+                    .append(" now=").append(now)
+                    .append(" joinAge=").append(now - pData.getLastJoinTime())
+                    .append(" keepAliveAge=").append(data.lastKeepAliveTime <= 0L ? -1L : now - data.lastKeepAliveTime)
+                    .append(" movingVL=").append(StringUtil.fdec3.format(data.movingVL))
+                    .append(" teleportGraceAge=").append(data.getMovingTeleportGraceAge(now))
+                    .append(" outgoingGraceAge=").append(data.getOutgoingPositionGraceAge(now))
+                    .append(" known=").append(LocUtil.simpleFormat(knownLocation))
+                    .append(" packet=").append(LocUtil.simpleFormat(packetLocation))
+                    .append(" hDist=").append(StringUtil.fdec3.format(hDistance))
+                    .append(" yDist=").append(StringUtil.fdec3.format(yDistance))
+                    .append(" distance=").append(StringUtil.fdec3.format(distance))
+                    .append(" vector=known-packet(").append(formatVector(knownLocation.getX() - packetLocation.getX(),
+                            knownLocation.getY() - packetLocation.getY(), knownLocation.getZ() - packetLocation.getZ())).append(')')
+                    .append(" packetMeta=").append(formatPacket(packetData, now))
+                    .append(" tags=").append(joinedTags)
+                    .toString());
+            player.getServer().getLogger().info(new StringBuilder(900)
+                    .append("[NCP][NetMoving][teleport] player=").append(player.getName())
+                    .append(" reason=").append(reason)
+                    .append(" ").append(data.describeMovingTeleportState(now, knownLocation, packetLocation, packetData))
+                    .toString());
+            player.getServer().getLogger().info(new StringBuilder(1100)
+                    .append("[NCP][NetMoving][model] player=").append(player.getName())
+                    .append(" reason=").append(reason)
+                    .append(" playerState=").append(formatPlayerState(player))
+                    .append(" movingData=").append(formatMovingData(mData, knownLocation))
+                    .append(" input=").append(formatKeyboardInput(mData.input))
+                    .append(" packetModel=").append(formatPacketModel(data, packetData, knownLocation, packetLocation, now))
+                    .toString());
+        }
+        catch (Throwable ignored) {}
+    }
+
+    private String formatPlayerState(final Player player) {
+        final Vector velocity = player.getVelocity();
+        return new StringBuilder(240)
+                .append("world=").append(player.getWorld() == null ? "null" : player.getWorld().getName())
+                .append(",gameMode=").append(player.getGameMode())
+                .append(",dead=").append(player.isDead())
+                .append(",health=").append(StringUtil.fdec3.format(player.getHealth()))
+                .append(",food=").append(player.getFoodLevel())
+                .append(",sprint=").append(player.isSprinting())
+                .append(",sneak=").append(player.isSneaking())
+                .append(",fly=").append(player.isFlying())
+                .append(",allowFlight=").append(player.getAllowFlight())
+                .append(",vehicle=").append(player.isInsideVehicle())
+                .append(",walkSpeed=").append(StringUtil.fdec3.format(player.getWalkSpeed()))
+                .append(",fall=").append(StringUtil.fdec3.format(player.getFallDistance()))
+                .append(",velocity=").append(formatVector(velocity.getX(), velocity.getY(), velocity.getZ()))
+                .toString();
+    }
+
+    private String formatMovingData(final MovingData data, final Location ref) {
+        final StringBuilder builder = new StringBuilder(700);
+        builder.append("{moveCount=").append(data.getPlayerMoveCount())
+                .append(",sfVL=").append(StringUtil.fdec3.format(data.survivalFlyVL))
+                .append(",sfJumpPhase=").append(data.sfJumpPhase)
+                .append(",liftOff=").append(data.liftOffEnvelope)
+                .append(",joinOrRespawn=").append(data.joinOrRespawn)
+                .append(",timeSinceSetBack=").append(data.timeSinceSetBack)
+                .append(",setBack=").append(data.hasSetBack() ? formatBukkitLocation(data.getSetBack(ref)) : "none")
+                .append(",morePacketsSetBack=").append(data.hasMorePacketsSetBack() ? formatBukkitLocation(data.getMorePacketsSetBack()) : "none")
+                .append(",teleported=").append(data.hasTeleported() ? formatBukkitLocation(data.getTeleported()) : "none")
+                .append(",speed=walk:").append(StringUtil.fdec3.format(data.walkSpeed))
+                .append("->").append(StringUtil.fdec3.format(data.nextWalkSpeed))
+                .append("/tick:").append(data.speedTick)
+                .append(",frictionH=").append(StringUtil.fdec3.format(data.lastFrictionHorizontal))
+                .append("->").append(StringUtil.fdec3.format(data.nextFrictionHorizontal))
+                .append(",stuckH=").append(StringUtil.fdec3.format(data.lastStuckInBlockHorizontal))
+                .append("->").append(StringUtil.fdec3.format(data.nextStuckInBlockHorizontal))
+                .append(",lastGravity=").append(StringUtil.fdec3.format(data.lastGravity))
+                .append(",nextGravity=").append(StringUtil.fdec3.format(data.nextGravity))
+                .append(",currentMove=").append(formatPlayerMove(data.playerMoves.getCurrentMove()))
+                .append(",lastMove=").append(formatPlayerMove(data.playerMoves.getFirstPastMove()))
+                .append('}');
+        return builder.toString();
+    }
+
+    private String formatPlayerMove(final PlayerMoveData move) {
+        final StringBuilder builder = new StringBuilder(500);
+        builder.append("{valid=").append(move.valid)
+                .append(",toValid=").append(move.toIsValid)
+                .append(",from=").append(formatLocationData(move.from));
+        if (move.toIsValid) {
+            builder.append(",to=").append(formatLocationData(move.to))
+                    .append(",actual=").append(formatVector(move.xDistance, move.yDistance, move.zDistance))
+                    .append(",h=").append(StringUtil.fdec3.format(move.hDistance))
+                    .append(",distSq=").append(StringUtil.fdec3.format(move.distanceSquared))
+                    .append(",allowed=").append(formatVector(move.xAllowedDistance, move.yAllowedDistance, move.zAllowedDistance))
+                    .append(",hAllowed=").append(StringUtil.fdec3.format(move.hAllowedDistance))
+                    .append(",over=").append(formatVector(move.xDistance - move.xAllowedDistance,
+                            move.yDistance - move.yAllowedDistance, move.zDistance - move.zAllowedDistance));
+        }
+        builder.append(",flyCheck=").append(move.flyCheck)
+                .append(",modelFlying=").append(move.modelFlying == null ? "none" : move.modelFlying.getClass().getSimpleName())
+                .append(",impulse=").append(move.hasImpulse).append('/').append(move.forwardImpulse).append('/').append(move.strafeImpulse)
+                .append(",collide=").append(move.collideX).append('/').append(move.collideY).append('/').append(move.collideZ)
+                .append(",hCollide=").append(move.collidesHorizontally)
+                .append(",minorHCollide=").append(move.negligibleHorizontalCollision)
+                .append(",touchedGround=").append(move.touchedGround)
+                .append(",lostGround=").append(move.fromLostGround).append('/').append(move.toLostGround)
+                .append(",jump=").append(move.isJump)
+                .append(",step=").append(move.isStepUp)
+                .append(",multi=").append(move.multiMoveCount)
+                .append(",hidden=").append(move.hiddenDistanceIndex).append('/').append(move.hiddenYDistanceIndex)
+                .append(",correctedPre=").append(formatVector(move.xCorrectedDistancePre, move.yCorrectedDistancePre, move.zCorrectedDistancePre))
+                .append(",correctedPost=").append(formatVector(move.xCorrectedDistancePost, 0.0, move.zCorrectedDistancePost))
+                .append(",verVelUsed=").append(move.verVelUsed)
+                .append('}');
+        return builder.toString();
+    }
+
+    private String formatPacketModel(final NetData data, final DataPacketFlying packetData,
+                                     final Location knownLocation, final Location packetLocation,
+                                     final long now) {
+        final DataPacketFlying[] flyingQueue = data.copyFlyingQueue();
+        final DataPacketInput[] inputQueue = data.copyInputQueue();
+        return new StringBuilder(900)
+                .append("{queueSize=").append(flyingQueue.length)
+                .append(",inputQueueSize=").append(inputQueue.length)
+                .append(",lastMatchedMoveToSeq=").append(data.getLastMatchedMoveToSequence())
+                .append(",currentPacketSeq=").append(packetData == null ? -1L : packetData.getSequence())
+                .append(",clientMotion=").append(formatClientMotion(flyingQueue))
+                .append(",knownFromPreviousPacket=").append(formatKnownFromPreviousPacket(flyingQueue, knownLocation))
+                .append(",packetFromKnown=").append(formatLocationDelta(knownLocation, packetLocation))
+                .append(",recentPackets=").append(formatFlyingQueue(flyingQueue, now))
+                .append(",recentInputs=").append(formatInputQueue(inputQueue))
+                .append('}')
+                .toString();
+    }
+
+    private String formatClientMotion(final DataPacketFlying[] queue) {
+        if (queue.length < 2 || !queue[0].hasPos || !queue[1].hasPos) {
+            return "none";
+        }
+        return formatPacketDelta(queue[1], queue[0]);
+    }
+
+    private String formatKnownFromPreviousPacket(final DataPacketFlying[] queue, final Location knownLocation) {
+        if (queue.length < 2 || !queue[1].hasPos) {
+            return "none";
+        }
+        return formatPositionDelta(queue[1].getX(), queue[1].getY(), queue[1].getZ(),
+                knownLocation.getX(), knownLocation.getY(), knownLocation.getZ());
+    }
+
+    private String formatFlyingQueue(final DataPacketFlying[] queue, final long now) {
+        if (queue.length == 0) {
+            return "[]";
+        }
+        final StringBuilder builder = new StringBuilder(500);
+        builder.append('[');
+        final int max = Math.min(queue.length, 6);
+        for (int i = 0; i < max; i++) {
+            if (i > 0) {
+                builder.append(';');
+            }
+            builder.append(formatPacket(queue[i], now));
+            if (i + 1 < queue.length && queue[i].hasPos && queue[i + 1].hasPos) {
+                builder.append(",dPrev=").append(formatPacketDelta(queue[i + 1], queue[i]));
+            }
+        }
+        if (queue.length > max) {
+            builder.append(";...");
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+
+    private String formatInputQueue(final DataPacketInput[] queue) {
+        if (queue.length == 0) {
+            return "[]";
+        }
+        final StringBuilder builder = new StringBuilder(220);
+        builder.append('[');
+        final int max = Math.min(queue.length, 6);
+        for (int i = 0; i < max; i++) {
+            if (i > 0) {
+                builder.append(';');
+            }
+            builder.append(formatInput(queue[i]));
+        }
+        if (queue.length > max) {
+            builder.append(";...");
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+
+    private String formatPacket(final DataPacketFlying packetData, final long now) {
+        if (packetData == null) {
+            return "null";
+        }
+        final StringBuilder builder = new StringBuilder(220);
+        builder.append("{seq=").append(packetData.getSequence())
+                .append(",age=").append(now >= packetData.time ? now - packetData.time : -(packetData.time - now))
+                .append(",type=").append(packetData.getSimplifiedContentType())
+                .append(",tracked=").append(packetData.isTracked())
+                .append(",ground=").append(packetData.onGround)
+                .append(",hCollision=").append(packetData.horizontalCollision);
+        if (packetData.hasPos) {
+            builder.append(",pos=").append(formatVector(packetData.getX(), packetData.getY(), packetData.getZ()));
+        }
+        if (packetData.hasLook) {
+            builder.append(",look=").append(StringUtil.fdec3.format(packetData.getYaw()))
+                    .append('/').append(StringUtil.fdec3.format(packetData.getPitch()));
+        }
+        builder.append('}');
+        return builder.toString();
+    }
+
+    private String formatKeyboardInput(final PlayerKeyboardInput input) {
+        return new StringBuilder(120)
+                .append("current=").append(input.getForwardDir()).append('/').append(input.getStrafeDir())
+                .append('(').append(StringUtil.fdec3.format(input.getForward())).append('/')
+                .append(StringUtil.fdec3.format(input.getStrafe())).append(')')
+                .append(",last=(").append(StringUtil.fdec3.format(input.getLastForward())).append('/')
+                .append(StringUtil.fdec3.format(input.getLastStrafe())).append(')')
+                .append(",keys=jump:").append(input.isSpaceBarPressed()).append("->").append(input.wasSpaceBarPressed())
+                .append(",sneak:").append(input.isShift()).append("->").append(input.wasShifting())
+                .append(",sprint:").append(input.isSprintingKeyPressed()).append("->").append(input.wasSprintingKeyPressed())
+                .toString();
+    }
+
+    private String formatInput(final DataPacketInput input) {
+        if (input == null) {
+            return "none";
+        }
+        return new StringBuilder(80)
+                .append("f:").append(input.forward)
+                .append(",b:").append(input.backward)
+                .append(",l:").append(input.left)
+                .append(",r:").append(input.right)
+                .append(",j:").append(input.jump)
+                .append(",shift:").append(input.shift)
+                .append(",sprint:").append(input.sprint)
+                .toString();
+    }
+
+    private String formatPacketDelta(final DataPacketFlying from, final DataPacketFlying to) {
+        return formatPositionDelta(from.getX(), from.getY(), from.getZ(), to.getX(), to.getY(), to.getZ());
+    }
+
+    private String formatLocationDelta(final Location from, final Location to) {
+        return formatPositionDelta(from.getX(), from.getY(), from.getZ(), to.getX(), to.getY(), to.getZ());
+    }
+
+    private String formatPositionDelta(final double fromX, final double fromY, final double fromZ,
+                                       final double toX, final double toY, final double toZ) {
+        final double xDistance = toX - fromX;
+        final double yDistance = toY - fromY;
+        final double zDistance = toZ - fromZ;
+        final double hDistance = Math.sqrt(xDistance * xDistance + zDistance * zDistance);
+        final double total = Math.sqrt(hDistance * hDistance + yDistance * yDistance);
+        return new StringBuilder(120)
+                .append("x=").append(StringUtil.fdec3.format(xDistance))
+                .append(",y=").append(StringUtil.fdec3.format(yDistance))
+                .append(",z=").append(StringUtil.fdec3.format(zDistance))
+                .append(",h=").append(StringUtil.fdec3.format(hDistance))
+                .append(",total=").append(StringUtil.fdec3.format(total))
+                .toString();
+    }
+
+    private String formatLocationData(final LocationData loc) {
+        final StringBuilder builder = new StringBuilder(140);
+        builder.append(loc.getWorldName()).append('@').append(LocUtil.simpleFormat(loc));
+        if (loc.extraPropertiesValid) {
+            builder.append(",ground=").append(loc.onGround)
+                    .append(",reset=").append(loc.resetCond)
+                    .append(",liquid=").append(loc.inLiquid)
+                    .append(",web=").append(loc.inWeb)
+                    .append(",powder=").append(loc.inPowderSnow)
+                    .append(",ice=").append(loc.onIce || loc.onBlueIce)
+                    .append(",slime=").append(loc.onSlimeBlock)
+                    .append(",honey=").append(loc.onHoneyBlock);
+        }
+        else {
+            builder.append(",flags=unknown");
+        }
+        return builder.toString();
+    }
+
+    private String formatBukkitLocation(final Location loc) {
+        return loc == null ? "null" : (loc.getWorld() == null ? "null" : loc.getWorld().getName()) + '@' + LocUtil.simpleFormat(loc);
+    }
+
+    private String formatVector(final double x, final double y, final double z) {
+        return StringUtil.fdec3.format(x) + "," + StringUtil.fdec3.format(y) + "," + StringUtil.fdec3.format(z);
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
@@ -15,6 +15,7 @@
 package fr.neatmonster.nocheatplus.checks.net;
 
 import java.util.LinkedList;
+import java.util.Iterator;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -49,6 +50,25 @@ import fr.neatmonster.nocheatplus.utilities.location.LocUtil;
  */
 public class NetData extends ACheckData {
 
+    private static final long MOVING_TELEPORT_GRACE_MS = 4000L;
+    private static final long MOVING_SERVER_JUMP_RECOVERY_GRACE_MS = 1500L;
+    private static final double MOVING_POSITION_MATCH_EPSILON = 0.03125D;
+    private static final double MOVING_SERVER_JUMP_DISTANCE = 100.0D;
+    private static final double MOVING_SERVER_JUMP_PACKET_DISTANCE = 64.0D;
+    private static final long MOVING_SERVER_JUMP_STALE_PACKET_MODEL_MS = 4000L;
+    private static final double MOVING_SERVER_JUMP_TARGET_MODEL_DISTANCE = 8.0D;
+    private static final double MOVING_STALE_PACKET_HORIZONTAL_BASE = 1.25D;
+    private static final double MOVING_STALE_PACKET_VERTICAL_BASE = 0.75D;
+    private static final double MOVING_STALE_PACKET_VERTICAL_PER_TICK = 0.30D;
+    private static final double MOVING_STALE_PACKET_VERTICAL_MAX = 4.0D;
+    private static final double MOVING_STALE_PACKET_MOTION_MULTIPLIER = 3.0D;
+    private static final long MOVING_TELEPORT_COMMAND_PENDING_MS = 15000L;
+    private static final long MOVING_TELEPORT_RESYNC_PENDING_MS = 4000L;
+    private static final double MOVING_TELEPORT_RESYNC_TARGET_DISTANCE = 8.0D;
+    private static final int MOVING_TELEPORT_RESYNC_NORMAL_STALE_PACKET_LIMIT = 2;
+    private static final long KEEP_ALIVE_REQUEST_MAX_AGE_MS = 30000L;
+    private static final int KEEP_ALIVE_REQUEST_MAX_PENDING = 40;
+
     // Reentrant lock.
     private final Lock lock = new ReentrantLock();
     private final Lock locki = new ReentrantLock();
@@ -62,6 +82,65 @@ public class NetData extends ACheckData {
 
     // Moving
     public double movingVL = 0;
+    // NetMoving diagnostics/model state: remember teleport and server-position packets for packet-order false flags.
+    private long lastMovingTeleportTime = 0L;
+    private String lastMovingTeleportWorld = null;
+    private String lastMovingTeleportCause = "none";
+    private double lastMovingTeleportX = 0.0;
+    private double lastMovingTeleportY = 0.0;
+    private double lastMovingTeleportZ = 0.0;
+    private float lastMovingTeleportYaw = 0.0f;
+    private float lastMovingTeleportPitch = 0.0f;
+    private long lastOutgoingPositionTime = 0L;
+    private boolean lastOutgoingPositionTracked = false;
+    private int lastOutgoingPositionTeleportId = Integer.MIN_VALUE;
+    private double lastOutgoingPositionX = 0.0;
+    private double lastOutgoingPositionY = 0.0;
+    private double lastOutgoingPositionZ = 0.0;
+    private float lastOutgoingPositionYaw = 0.0f;
+    private float lastOutgoingPositionPitch = 0.0f;
+    private long lastMovingKnownLocationTime = 0L;
+    private String lastMovingKnownLocationWorld = null;
+    private double lastMovingKnownLocationX = 0.0;
+    private double lastMovingKnownLocationY = 0.0;
+    private double lastMovingKnownLocationZ = 0.0;
+    private float lastMovingKnownLocationYaw = 0.0f;
+    private float lastMovingKnownLocationPitch = 0.0f;
+    private long lastServerPositionJumpTime = 0L;
+    private String lastServerPositionJumpFromWorld = null;
+    private String lastServerPositionJumpToWorld = null;
+    private double lastServerPositionJumpFromX = 0.0;
+    private double lastServerPositionJumpFromY = 0.0;
+    private double lastServerPositionJumpFromZ = 0.0;
+    private float lastServerPositionJumpFromYaw = 0.0f;
+    private float lastServerPositionJumpFromPitch = 0.0f;
+    private double lastServerPositionJumpToX = 0.0;
+    private double lastServerPositionJumpToY = 0.0;
+    private double lastServerPositionJumpToZ = 0.0;
+    private float lastServerPositionJumpToYaw = 0.0f;
+    private float lastServerPositionJumpToPitch = 0.0f;
+    private long lastServerPositionJumpRecoveryUsedTime = 0L;
+    private long lastTeleportCommandTime = 0L;
+    private String lastTeleportCommand = "none";
+    private String lastTeleportCommandWorld = null;
+    private double lastTeleportCommandX = 0.0;
+    private double lastTeleportCommandY = 0.0;
+    private double lastTeleportCommandZ = 0.0;
+    private float lastTeleportCommandYaw = 0.0f;
+    private float lastTeleportCommandPitch = 0.0f;
+    private long lastTeleportResyncMovingDataKey = 0L;
+    private long lastTeleportResyncRequestTime = 0L;
+    private long lastTeleportResyncAppliedKey = 0L;
+    private String lastTeleportResyncReason = "none";
+    private String lastTeleportResyncWorld = null;
+    private double lastTeleportResyncX = 0.0;
+    private double lastTeleportResyncY = 0.0;
+    private double lastTeleportResyncZ = 0.0;
+    private float lastTeleportResyncYaw = 0.0f;
+    private float lastTeleportResyncPitch = 0.0f;
+    private long lastTeleportResyncDroppedPacketLogTime = 0L;
+    private int lastTeleportResyncDroppedPacketCount = 0;
+    private int lastTeleportResyncPendingDropLogCount = 0;
 
     // KeepAliveFrequency
     /**
@@ -69,6 +148,34 @@ public class NetData extends ACheckData {
      * time of the last event. System.currentTimeMillis() is used.
      */
     public ActionFrequency keepAliveFreq = new ActionFrequency(20, 1000);
+    public long keepAlivePacketTime = 0L;
+    public long keepAlivePreviousPacketTime = 0L;
+    public long keepAlivePacketDelta = -1L;
+    public long keepAlivePacketId = 0L;
+    public long keepAlivePreviousPacketId = 0L;
+    public boolean keepAlivePacketIdAvailable = false;
+    public boolean keepAlivePreviousPacketIdAvailable = false;
+    public boolean keepAliveDuplicateId = false;
+    // KeepAlive diagnostics: record packet shape/thread so async Folia timing is visible in console logs.
+    public String keepAlivePacketIdType = "none";
+    public int keepAlivePacketLongCount = -1;
+    public int keepAlivePacketIntCount = -1;
+    public boolean keepAlivePacketAsync = false;
+    public String keepAlivePacketThread = "unknown";
+    // KeepAlive model: expected client replies should match a recent outgoing server keepalive id.
+    private final LinkedList<KeepAliveRequest> keepAliveRequests = new LinkedList<KeepAliveRequest>();
+    public boolean keepAliveOutgoingSeen = false;
+    public long keepAliveOutgoingPacketTime = 0L;
+    public long keepAliveOutgoingPacketId = 0L;
+    public boolean keepAliveOutgoingPacketIdAvailable = false;
+    public String keepAliveOutgoingPacketIdType = "none";
+    public int keepAliveOutgoingPacketLongCount = -1;
+    public int keepAliveOutgoingPacketIntCount = -1;
+    public boolean keepAliveOutgoingPacketAsync = false;
+    public String keepAliveOutgoingPacketThread = "unknown";
+    public boolean keepAliveExpectedResponse = false;
+    public long keepAliveExpectedResponseAge = -1L;
+    public int keepAlivePendingRequests = 0;
 	
     // Wrong Turn
     public double wrongTurnVL = 0;
@@ -123,13 +230,736 @@ public class NetData extends ACheckData {
     }
 
     public void onJoin(final Player player) {
+        resetMovingTeleportDiagnostics();
         teleportQueue.clear();
         clearFlyingQueue();
+        clearKeepAliveTracking();
     }
 
     public void onLeave(Player player) {
+        resetMovingTeleportDiagnostics();
         teleportQueue.clear();
         clearFlyingQueue();
+        clearKeepAliveTracking();
+    }
+
+    /**
+     * Register a Bukkit teleport for packet-level moving checks.
+     */
+    public void recordTeleportEvent(final Location loc) {
+        recordTeleportEvent(loc, "unknown");
+    }
+
+    /**
+     * Register a Bukkit teleport for packet-level moving checks.
+     */
+    public void recordTeleportEvent(final Location loc, final String cause) {
+        lastMovingTeleportTime = System.currentTimeMillis();
+        lastMovingTeleportCause = cause == null ? "unknown" : cause;
+        movingVL *= 0.5;
+        clearFlyingQueue();
+        if (loc != null) {
+            lastMovingTeleportWorld = loc.getWorld() == null ? "null" : loc.getWorld().getName();
+            lastMovingTeleportX = loc.getX();
+            lastMovingTeleportY = loc.getY();
+            lastMovingTeleportZ = loc.getZ();
+            lastMovingTeleportYaw = loc.getYaw();
+            lastMovingTeleportPitch = loc.getPitch();
+            teleportQueue.onTeleportEvent(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
+        }
+    }
+
+    /**
+     * Register every outgoing server position packet, including ones not matched
+     * to a Bukkit PlayerTeleportEvent. This catches packet/event ordering races.
+     */
+    public void recordOutgoingPosition(final double x, final double y, final double z,
+                                       final float yaw, final float pitch,
+                                       final int teleportId, final boolean tracked,
+                                       final long time) {
+        lastOutgoingPositionTime = time;
+        lastOutgoingPositionTracked = tracked;
+        lastOutgoingPositionTeleportId = teleportId;
+        lastOutgoingPositionX = x;
+        lastOutgoingPositionY = y;
+        lastOutgoingPositionZ = z;
+        lastOutgoingPositionYaw = yaw;
+        lastOutgoingPositionPitch = pitch;
+    }
+
+    public void recordKeepAlivePacket(final long time, final boolean idAvailable, final long id,
+                                      final String idType, final int longCount, final int intCount,
+                                      final boolean async, final String threadName) {
+        keepAlivePreviousPacketTime = keepAlivePacketTime;
+        keepAlivePreviousPacketId = keepAlivePacketId;
+        keepAlivePreviousPacketIdAvailable = keepAlivePacketIdAvailable;
+        keepAlivePacketDelta = keepAlivePreviousPacketTime <= 0L ? -1L : time - keepAlivePreviousPacketTime;
+        keepAlivePacketTime = time;
+        keepAlivePacketIdAvailable = idAvailable;
+        keepAlivePacketId = id;
+        keepAlivePacketIdType = idType == null ? "none" : idType;
+        keepAlivePacketLongCount = longCount;
+        keepAlivePacketIntCount = intCount;
+        keepAlivePacketAsync = async;
+        keepAlivePacketThread = threadName == null ? "unknown" : threadName;
+        keepAliveDuplicateId = idAvailable && keepAlivePreviousPacketIdAvailable && id == keepAlivePreviousPacketId;
+        keepAliveExpectedResponse = false;
+        keepAliveExpectedResponseAge = -1L;
+        synchronized (keepAliveRequests) {
+            pruneKeepAliveRequests(time);
+            if (idAvailable) {
+                final Iterator<KeepAliveRequest> iterator = keepAliveRequests.iterator();
+                while (iterator.hasNext()) {
+                    final KeepAliveRequest request = iterator.next();
+                    if (request.id == id) {
+                        keepAliveExpectedResponse = true;
+                        keepAliveExpectedResponseAge = Math.max(0L, time - request.time);
+                        iterator.remove();
+                        break;
+                    }
+                }
+            }
+            keepAlivePendingRequests = keepAliveRequests.size();
+        }
+    }
+
+    public void recordOutgoingKeepAlivePacket(final long time, final boolean idAvailable, final long id,
+                                             final String idType, final int longCount, final int intCount,
+                                             final boolean async, final String threadName) {
+        keepAliveOutgoingSeen = true;
+        keepAliveOutgoingPacketTime = time;
+        keepAliveOutgoingPacketIdAvailable = idAvailable;
+        keepAliveOutgoingPacketId = id;
+        keepAliveOutgoingPacketIdType = idType == null ? "none" : idType;
+        keepAliveOutgoingPacketLongCount = longCount;
+        keepAliveOutgoingPacketIntCount = intCount;
+        keepAliveOutgoingPacketAsync = async;
+        keepAliveOutgoingPacketThread = threadName == null ? "unknown" : threadName;
+        synchronized (keepAliveRequests) {
+            pruneKeepAliveRequests(time);
+            if (idAvailable) {
+                keepAliveRequests.addFirst(new KeepAliveRequest(time, id));
+                while (keepAliveRequests.size() > KEEP_ALIVE_REQUEST_MAX_PENDING) {
+                    keepAliveRequests.removeLast();
+                }
+            }
+            keepAlivePendingRequests = keepAliveRequests.size();
+        }
+    }
+
+    private void pruneKeepAliveRequests(final long time) {
+        while (!keepAliveRequests.isEmpty()
+                && time - keepAliveRequests.getLast().time > KEEP_ALIVE_REQUEST_MAX_AGE_MS) {
+            keepAliveRequests.removeLast();
+        }
+    }
+
+    private void clearKeepAliveTracking() {
+        synchronized (keepAliveRequests) {
+            keepAliveRequests.clear();
+            keepAlivePendingRequests = 0;
+        }
+        keepAliveOutgoingSeen = false;
+        keepAliveOutgoingPacketTime = 0L;
+        keepAliveOutgoingPacketId = 0L;
+        keepAliveOutgoingPacketIdAvailable = false;
+        keepAliveOutgoingPacketIdType = "none";
+        keepAliveOutgoingPacketLongCount = -1;
+        keepAliveOutgoingPacketIntCount = -1;
+        keepAliveOutgoingPacketAsync = false;
+        keepAliveOutgoingPacketThread = "unknown";
+        keepAliveExpectedResponse = false;
+        keepAliveExpectedResponseAge = -1L;
+    }
+
+    /**
+     * Track the server-side player location seen by NET_MOVING. If it suddenly
+     * jumps far away, stale client packets near the previous server location are
+     * very likely plugin-teleport leftovers.
+     */
+    public void recordMovingKnownLocation(final Location loc, final long now) {
+        if (loc == null) {
+            return;
+        }
+        final String world = loc.getWorld() == null ? "null" : loc.getWorld().getName();
+        if (lastMovingKnownLocationTime > 0L) {
+            final boolean worldChanged = lastMovingKnownLocationWorld == null
+                || !lastMovingKnownLocationWorld.equals(world);
+            final double distance = distance(lastMovingKnownLocationX, lastMovingKnownLocationY, lastMovingKnownLocationZ,
+                    loc.getX(), loc.getY(), loc.getZ());
+            if (worldChanged || distance > MOVING_SERVER_JUMP_DISTANCE) {
+                lastServerPositionJumpTime = now;
+                lastServerPositionJumpFromWorld = lastMovingKnownLocationWorld;
+                lastServerPositionJumpFromX = lastMovingKnownLocationX;
+                lastServerPositionJumpFromY = lastMovingKnownLocationY;
+                lastServerPositionJumpFromZ = lastMovingKnownLocationZ;
+                lastServerPositionJumpFromYaw = lastMovingKnownLocationYaw;
+                lastServerPositionJumpFromPitch = lastMovingKnownLocationPitch;
+                lastServerPositionJumpToWorld = world;
+                lastServerPositionJumpToX = loc.getX();
+                lastServerPositionJumpToY = loc.getY();
+                lastServerPositionJumpToZ = loc.getZ();
+                lastServerPositionJumpToYaw = loc.getYaw();
+                lastServerPositionJumpToPitch = loc.getPitch();
+            }
+        }
+        lastMovingKnownLocationTime = now;
+        lastMovingKnownLocationWorld = world;
+        lastMovingKnownLocationX = loc.getX();
+        lastMovingKnownLocationY = loc.getY();
+        lastMovingKnownLocationZ = loc.getZ();
+        lastMovingKnownLocationYaw = loc.getYaw();
+        lastMovingKnownLocationPitch = loc.getPitch();
+    }
+
+    /**
+     * Mark that a command likely to teleport the player has been issued.
+     */
+    public void recordTeleportCommand(final String command, final Location loc, final long now) {
+        lastTeleportCommandTime = now;
+        lastTeleportCommand = command == null ? "unknown" : command;
+        if (loc != null) {
+            lastTeleportCommandWorld = loc.getWorld() == null ? "null" : loc.getWorld().getName();
+            lastTeleportCommandX = loc.getX();
+            lastTeleportCommandY = loc.getY();
+            lastTeleportCommandZ = loc.getZ();
+            lastTeleportCommandYaw = loc.getYaw();
+            lastTeleportCommandPitch = loc.getPitch();
+        }
+    }
+
+    public boolean isWithinMovingTeleportGrace(final long now) {
+        return lastMovingTeleportTime > 0L
+            && now >= lastMovingTeleportTime
+            && now - lastMovingTeleportTime <= MOVING_TELEPORT_GRACE_MS;
+    }
+
+    public boolean isWithinOutgoingPositionGrace(final long now, final Location knownLocation) {
+        return lastOutgoingPositionTime > 0L
+            && now >= lastOutgoingPositionTime
+            && now - lastOutgoingPositionTime <= MOVING_TELEPORT_GRACE_MS
+            && matchesPosition(lastOutgoingPositionX, lastOutgoingPositionY, lastOutgoingPositionZ, knownLocation);
+    }
+
+    public boolean consumeExpectedOutgoingPosition(final DataPacketFlying packetData) {
+        // Folia/respawn compatibility: the move can arrive before the outgoing teleport packet is recorded.
+        return teleportQueue.consumeExpectedOutgoingPosition(packetData);
+    }
+
+    public boolean isWithinServerPositionJumpGrace(final long now, final Location knownLocation, final Location packetLocation) {
+        return lastServerPositionJumpTime > 0L
+            && now >= lastServerPositionJumpTime
+            && now - lastServerPositionJumpTime <= MOVING_TELEPORT_GRACE_MS
+            && distanceToStored(lastServerPositionJumpToX, lastServerPositionJumpToY, lastServerPositionJumpToZ, knownLocation) <= MOVING_SERVER_JUMP_PACKET_DISTANCE
+            && distanceToStored(lastServerPositionJumpFromX, lastServerPositionJumpFromY, lastServerPositionJumpFromZ, packetLocation) <= MOVING_SERVER_JUMP_PACKET_DISTANCE;
+    }
+
+    public boolean isWithinServerPositionJumpStalePacketModel(final long now,
+                                                              final Location knownLocation,
+                                                              final Location packetLocation,
+                                                              final DataPacketFlying packetData) {
+        // Teleport model: Folia/async teleports can leave pre-teleport packets in flight after the server moved.
+        return lastServerPositionJumpTime > 0L
+            && now >= lastServerPositionJumpTime
+            && now - lastServerPositionJumpTime <= MOVING_SERVER_JUMP_STALE_PACKET_MODEL_MS
+            && distanceToStored(lastServerPositionJumpToX, lastServerPositionJumpToY, lastServerPositionJumpToZ,
+                    knownLocation) <= MOVING_SERVER_JUMP_TARGET_MODEL_DISTANCE
+            && isStalePacketNearStoredPositionModel(packetLocation, packetData,
+                    lastServerPositionJumpFromX, lastServerPositionJumpFromY, lastServerPositionJumpFromZ,
+                    now - lastServerPositionJumpTime);
+    }
+
+    public boolean consumeServerPositionJumpRecoveryGrace(final long now, final Location knownLocation) {
+        // Folia/death compatibility: allow one stale packet after a server-side jump even if it matches neither endpoint.
+        if (lastServerPositionJumpTime <= 0L
+                || now < lastServerPositionJumpTime
+                || now - lastServerPositionJumpTime > MOVING_SERVER_JUMP_RECOVERY_GRACE_MS
+                || lastServerPositionJumpRecoveryUsedTime == lastServerPositionJumpTime
+                || distanceToStored(lastServerPositionJumpToX, lastServerPositionJumpToY, lastServerPositionJumpToZ, knownLocation) > MOVING_SERVER_JUMP_PACKET_DISTANCE) {
+            return false;
+        }
+        lastServerPositionJumpRecoveryUsedTime = lastServerPositionJumpTime;
+        return true;
+    }
+
+    public boolean isWithinTeleportCommandGrace(final long now, final Location knownLocation, final Location packetLocation) {
+        return lastTeleportCommandTime > 0L
+            && now >= lastTeleportCommandTime
+            && now - lastTeleportCommandTime <= MOVING_TELEPORT_COMMAND_PENDING_MS
+            && distanceToStored(lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ, knownLocation) > MOVING_SERVER_JUMP_DISTANCE
+            && distanceToStored(lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ, packetLocation) <= MOVING_SERVER_JUMP_PACKET_DISTANCE;
+    }
+
+    public boolean isWithinTeleportCommandStalePacketModel(final long now,
+                                                          final Location knownLocation,
+                                                          final Location packetLocation,
+                                                          final DataPacketFlying packetData) {
+        // Teleport command model: command plugins can async-teleport before Bukkit's event/order data is visible here.
+        return lastTeleportCommandTime > 0L
+            && now >= lastTeleportCommandTime
+            && now - lastTeleportCommandTime <= MOVING_TELEPORT_COMMAND_PENDING_MS
+            && distanceToStored(lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ,
+                    knownLocation) > MOVING_SERVER_JUMP_DISTANCE
+            && isStalePacketNearStoredPositionModel(packetLocation, packetData,
+                    lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ,
+                    now - lastTeleportCommandTime);
+    }
+
+    public void acceptMovingTeleportResync(final Player player, final Plugin plugin, final MovingData mData,
+                                           final Location knownLocation, final Location packetLocation,
+                                           final DataPacketFlying packetData, final long now, final String reason) {
+        // Teleport model: accepted stale packets are packet-order leftovers, not valid post-teleport history.
+        movingVL *= 0.5;
+        final int queueSizeBeforeClear = getFlyingQueueSize();
+        clearFlyingQueue();
+        if (player == null || plugin == null || mData == null || knownLocation == null
+                || knownLocation.getWorld() == null) {
+            return;
+        }
+        final Location modelLocation = LocUtil.clone(knownLocation);
+        final long resyncKey = Math.max(lastServerPositionJumpTime, lastTeleportCommandTime);
+        if (resyncKey <= 0L || lastTeleportResyncMovingDataKey == resyncKey) {
+            return;
+        }
+        lastTeleportResyncMovingDataKey = resyncKey;
+        recordPendingTeleportResync(resyncKey, modelLocation, now, reason);
+        logTeleportResyncStalePacketDrop(player, now, modelLocation, packetLocation, packetData,
+                reason, "opened", queueSizeBeforeClear, true);
+        final Object task = SchedulerHelper.runSyncTaskForEntity(player, plugin, (arg) -> {
+            if (lastTeleportResyncAppliedKey == resyncKey) {
+                return;
+            }
+            Location syncLocation = null;
+            try {
+                syncLocation = player.isOnline() ? player.getLocation() : null;
+            }
+            catch (Throwable ignored) {}
+            // Folia model sync: refresh MovingData only on the player's owning region thread.
+            mData.onExternalTeleportResync(syncLocation != null && syncLocation.getWorld() != null
+                    ? syncLocation : modelLocation);
+            markTeleportResyncApplied(resyncKey);
+            if (shouldLogTeleportResyncSuccessToConsole()) {
+                player.getServer().getLogger().info(NetDiagnostics.formatTeleportResyncApplied(player.getName(),
+                        "applied", reason, lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                        lastTeleportResyncYaw, lastTeleportResyncPitch));
+            }
+        }, null);
+        if (!SchedulerHelper.isTaskScheduled(task)) {
+            StaticLog.logWarning("Failed to schedule teleport resync moving-data refresh for player: "
+                    + player.getName() + " (" + (reason == null ? "unknown" : reason) + ")");
+        }
+    }
+
+    public boolean isWithinTeleportResyncStalePacketDropModel(final long now,
+                                                              final Location knownLocation,
+                                                              final Location packetLocation,
+                                                              final DataPacketFlying packetData) {
+        if (lastTeleportResyncMovingDataKey <= 0L
+                || lastTeleportResyncRequestTime <= 0L
+                || now < lastTeleportResyncRequestTime
+                || now - lastTeleportResyncRequestTime > MOVING_TELEPORT_RESYNC_PENDING_MS
+                || distanceToStored(lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                        knownLocation) > MOVING_TELEPORT_RESYNC_TARGET_DISTANCE) {
+            return false;
+        }
+        final long serverJumpAge = lastServerPositionJumpTime <= 0L ? Long.MAX_VALUE : now - lastServerPositionJumpTime;
+        if (lastServerPositionJumpTime > 0L
+                && serverJumpAge >= 0L
+                && serverJumpAge <= MOVING_SERVER_JUMP_STALE_PACKET_MODEL_MS
+                && isStalePacketNearStoredPositionModel(packetLocation, packetData,
+                        lastServerPositionJumpFromX, lastServerPositionJumpFromY,
+                        lastServerPositionJumpFromZ, serverJumpAge)) {
+            return true;
+        }
+        final long commandAge = lastTeleportCommandTime <= 0L ? Long.MAX_VALUE : now - lastTeleportCommandTime;
+        return lastTeleportCommandTime > 0L
+                && commandAge >= 0L
+                && commandAge <= MOVING_TELEPORT_COMMAND_PENDING_MS
+                && isStalePacketNearStoredPositionModel(packetLocation, packetData,
+                        lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ, commandAge);
+    }
+
+    public void acceptMovingTeleportStalePacketContinuation(final Player player,
+                                                            final Location knownLocation,
+                                                            final Location packetLocation,
+                                                            final DataPacketFlying packetData,
+                                                            final long now,
+                                                            final String reason) {
+        // Teleport model: additional old-location packets after resync are deleted from packet history.
+        movingVL *= 0.5;
+        final int queueSizeBeforeClear = getFlyingQueueSize();
+        clearFlyingQueue();
+        logTeleportResyncStalePacketDrop(player, now, knownLocation, packetLocation, packetData,
+                reason, "continuation", queueSizeBeforeClear, false);
+    }
+
+    /**
+     * Apply a pending teleport resync from the player move path, where MovingData
+     * is owned by the correct Folia region. This prevents stale pre-teleport
+     * set backs from surviving until the next scheduled entity task.
+     */
+    public boolean applyPendingTeleportResync(final Player player, final MovingData mData,
+                                              final Location eventFrom, final Location eventTo,
+                                              final long now) {
+        if (player == null || mData == null || lastTeleportResyncMovingDataKey <= 0L
+                || lastTeleportResyncAppliedKey == lastTeleportResyncMovingDataKey
+                || lastTeleportResyncRequestTime <= 0L
+                || now < lastTeleportResyncRequestTime
+                || now - lastTeleportResyncRequestTime > MOVING_TELEPORT_RESYNC_PENDING_MS) {
+            return false;
+        }
+        final Location modelTarget = getPendingTeleportResyncTarget();
+        if (modelTarget == null) {
+            return false;
+        }
+        Location current = null;
+        try {
+            current = player.isOnline() ? player.getLocation() : null;
+        }
+        catch (Throwable ignored) {}
+        final Location appliedTarget = isWorldBackedPendingTeleportTarget(current) ? current
+                : isWorldBackedPendingTeleportTarget(eventTo) ? eventTo
+                : isWorldBackedPendingTeleportTarget(eventFrom) ? eventFrom
+                : null;
+        if (appliedTarget == null) {
+            return false;
+        }
+        // Teleport/Folia model: move-event code is region-safe, so clear old movement history immediately.
+        mData.onExternalTeleportResync(appliedTarget);
+        markTeleportResyncApplied(lastTeleportResyncMovingDataKey);
+        if (shouldLogTeleportResyncSuccessToConsole()) {
+            player.getServer().getLogger().info(NetDiagnostics.formatTeleportResyncApplied(player.getName(),
+                    "applied_move_event", lastTeleportResyncReason,
+                    lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                    lastTeleportResyncYaw, lastTeleportResyncPitch));
+        }
+        return true;
+    }
+
+    private void recordPendingTeleportResync(final long resyncKey, final Location loc,
+                                             final long now, final String reason) {
+        lastTeleportResyncRequestTime = now;
+        lastTeleportResyncReason = reason == null ? "unknown" : reason;
+        lastTeleportResyncWorld = loc.getWorld() == null ? "null" : loc.getWorld().getName();
+        lastTeleportResyncX = loc.getX();
+        lastTeleportResyncY = loc.getY();
+        lastTeleportResyncZ = loc.getZ();
+        lastTeleportResyncYaw = loc.getYaw();
+        lastTeleportResyncPitch = loc.getPitch();
+        if (lastTeleportResyncAppliedKey != resyncKey) {
+            lastTeleportResyncAppliedKey = 0L;
+        }
+        lastTeleportResyncDroppedPacketLogTime = 0L;
+        lastTeleportResyncDroppedPacketCount = 0;
+        lastTeleportResyncPendingDropLogCount = 0;
+    }
+
+    private void markTeleportResyncApplied(final long resyncKey) {
+        if (resyncKey > 0L) {
+            lastTeleportResyncAppliedKey = resyncKey;
+        }
+    }
+
+    private Location getPendingTeleportResyncTarget() {
+        if (lastTeleportResyncMovingDataKey <= 0L || lastTeleportResyncWorld == null) {
+            return null;
+        }
+        return new Location(null, lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                lastTeleportResyncYaw, lastTeleportResyncPitch);
+    }
+
+    private boolean isNearPendingTeleportTarget(final Location loc) {
+        if (loc == null) {
+            return false;
+        }
+        if (loc.getWorld() != null && lastTeleportResyncWorld != null
+                && !"null".equals(lastTeleportResyncWorld)
+                && !lastTeleportResyncWorld.equals(loc.getWorld().getName())) {
+            return false;
+        }
+        return distanceToStored(lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ, loc)
+                <= MOVING_TELEPORT_RESYNC_TARGET_DISTANCE;
+    }
+
+    private boolean isWorldBackedPendingTeleportTarget(final Location loc) {
+        // Folia packet safety: only real Bukkit-world locations may be stored as MovingData set backs.
+        return loc != null && loc.getWorld() != null && isNearPendingTeleportTarget(loc);
+    }
+
+    private boolean isStalePacketNearStoredPositionModel(final Location packetLocation,
+                                                        final DataPacketFlying packetData,
+                                                        final double storedX,
+                                                        final double storedY,
+                                                        final double storedZ,
+                                                        final long age) {
+        if (packetLocation == null || packetData == null || !packetData.hasPos) {
+            return false;
+        }
+        final double horizontal = horizontalDistance(storedX, storedZ, packetLocation.getX(), packetLocation.getZ());
+        final double vertical = Math.abs(packetLocation.getY() - storedY);
+        return horizontal <= getStalePacketHorizontalModel(packetData)
+                && vertical <= getStalePacketVerticalModel(packetData, age);
+    }
+
+    private double getStalePacketHorizontalModel(final DataPacketFlying packetData) {
+        final DataPacketFlying previous = getPreviousPositionPacket(packetData);
+        if (previous == null) {
+            return MOVING_STALE_PACKET_HORIZONTAL_BASE;
+        }
+        final double motion = horizontalDistance(previous.getX(), previous.getZ(), packetData.getX(), packetData.getZ());
+        return Math.max(MOVING_STALE_PACKET_HORIZONTAL_BASE,
+                motion * MOVING_STALE_PACKET_MOTION_MULTIPLIER + MOVING_POSITION_MATCH_EPSILON);
+    }
+
+    private double getStalePacketVerticalModel(final DataPacketFlying packetData, final long age) {
+        final double ageTicks = Math.max(1.0D, Math.ceil(Math.max(0L, age) / 50.0D) + 1.0D);
+        final double ageEnvelope = MOVING_STALE_PACKET_VERTICAL_BASE
+                + ageTicks * MOVING_STALE_PACKET_VERTICAL_PER_TICK;
+        final DataPacketFlying previous = getPreviousPositionPacket(packetData);
+        if (previous == null) {
+            return Math.min(MOVING_STALE_PACKET_VERTICAL_MAX, ageEnvelope);
+        }
+        final double motion = Math.abs(packetData.getY() - previous.getY());
+        return Math.min(MOVING_STALE_PACKET_VERTICAL_MAX,
+                Math.max(ageEnvelope, motion * MOVING_STALE_PACKET_MOTION_MULTIPLIER
+                        + MOVING_STALE_PACKET_VERTICAL_BASE));
+    }
+
+    private DataPacketFlying getPreviousPositionPacket(final DataPacketFlying packetData) {
+        if (packetData == null) {
+            return null;
+        }
+        lock.lock();
+        try {
+            boolean foundCurrent = false;
+            for (final DataPacketFlying packet : flyingQueue) {
+                if (packet == null || !packet.hasPos) {
+                    continue;
+                }
+                if (foundCurrent) {
+                    return packet;
+                }
+                if (packet == packetData || packet.getSequence() == packetData.getSequence()) {
+                    foundCurrent = true;
+                }
+            }
+            return null;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public long getMovingTeleportGraceAge(final long now) {
+        return lastMovingTeleportTime <= 0L ? -1L : now - lastMovingTeleportTime;
+    }
+
+    public long getOutgoingPositionGraceAge(final long now) {
+        return lastOutgoingPositionTime <= 0L ? -1L : now - lastOutgoingPositionTime;
+    }
+
+    public long getServerPositionJumpGraceAge(final long now) {
+        return lastServerPositionJumpTime <= 0L ? -1L : now - lastServerPositionJumpTime;
+    }
+
+    public long getTeleportCommandGraceAge(final long now) {
+        return lastTeleportCommandTime <= 0L ? -1L : now - lastTeleportCommandTime;
+    }
+
+    public String describeMovingTeleportState(final long now, final Location knownLocation,
+                                              final Location packetLocation,
+                                              final DataPacketFlying packetData) {
+        return new StringBuilder(500)
+                .append("eventAge=").append(getMovingTeleportGraceAge(now))
+                .append(",eventWithinGrace=").append(isWithinMovingTeleportGrace(now))
+                .append(",eventCause=").append(lastMovingTeleportCause)
+                .append(",eventLoc=").append(formatTeleportEventLocation())
+                .append(",eventToKnown=").append(NetDiagnostics.formatStoredDistance(lastMovingTeleportTime, lastMovingTeleportX, lastMovingTeleportY, lastMovingTeleportZ, knownLocation))
+                .append(",eventToPacket=").append(NetDiagnostics.formatStoredDistance(lastMovingTeleportTime, lastMovingTeleportX, lastMovingTeleportY, lastMovingTeleportZ, packetLocation))
+                .append(",outgoingAge=").append(getOutgoingPositionGraceAge(now))
+                .append(",outgoingWithinGrace=").append(isWithinOutgoingPositionGrace(now, knownLocation))
+                .append(",outgoingTracked=").append(lastOutgoingPositionTracked)
+                .append(",outgoingTeleportId=").append(lastOutgoingPositionTeleportId)
+                .append(",outgoingLoc=").append(formatOutgoingPositionLocation())
+                .append(",outgoingToKnown=").append(NetDiagnostics.formatStoredDistance(lastOutgoingPositionTime, lastOutgoingPositionX, lastOutgoingPositionY, lastOutgoingPositionZ, knownLocation))
+                .append(",outgoingToPacket=").append(NetDiagnostics.formatStoredDistance(lastOutgoingPositionTime, lastOutgoingPositionX, lastOutgoingPositionY, lastOutgoingPositionZ, packetLocation))
+                .append(",serverJumpAge=").append(getServerPositionJumpGraceAge(now))
+                .append(",serverJumpWithinGrace=").append(isWithinServerPositionJumpGrace(now, knownLocation, packetLocation))
+                .append(",serverJumpStalePacketModel=").append(isWithinServerPositionJumpStalePacketModel(now,
+                        knownLocation, packetLocation, packetData))
+                .append(",serverJumpFrom=").append(formatServerJumpFrom())
+                .append(",serverJumpTo=").append(formatServerJumpTo())
+                .append(",serverJumpToKnown=").append(NetDiagnostics.formatStoredDistance(lastServerPositionJumpTime, lastServerPositionJumpToX, lastServerPositionJumpToY, lastServerPositionJumpToZ, knownLocation))
+                .append(",serverJumpFromPacket=").append(NetDiagnostics.formatStoredDistance(lastServerPositionJumpTime, lastServerPositionJumpFromX, lastServerPositionJumpFromY, lastServerPositionJumpFromZ, packetLocation))
+                .append(",commandAge=").append(getTeleportCommandGraceAge(now))
+                .append(",commandWithinGrace=").append(isWithinTeleportCommandGrace(now, knownLocation, packetLocation))
+                .append(",commandStalePacketModel=").append(isWithinTeleportCommandStalePacketModel(now,
+                        knownLocation, packetLocation, packetData))
+                .append(",command=").append(lastTeleportCommand)
+                .append(",commandLoc=").append(formatTeleportCommandLocation())
+                .append(",commandToKnown=").append(NetDiagnostics.formatStoredDistance(lastTeleportCommandTime, lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ, knownLocation))
+                .append(",commandToPacket=").append(NetDiagnostics.formatStoredDistance(lastTeleportCommandTime, lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ, packetLocation))
+                .append(",resync=").append(describeTeleportResyncState(now, knownLocation))
+                .append(",queue=").append(teleportQueue.getDebugState(now))
+                .toString();
+    }
+
+    public String describeKeepAliveState(final long now) {
+        return NetDiagnostics.formatKeepAliveState(this, now);
+    }
+
+    private static final class KeepAliveRequest {
+        private final long time;
+        private final long id;
+
+        private KeepAliveRequest(final long time, final long id) {
+            this.time = time;
+            this.id = id;
+        }
+    }
+
+    private void resetMovingTeleportDiagnostics() {
+        lastMovingTeleportTime = 0L;
+        lastMovingTeleportWorld = null;
+        lastMovingTeleportCause = "none";
+        lastOutgoingPositionTime = 0L;
+        lastOutgoingPositionTracked = false;
+        lastOutgoingPositionTeleportId = Integer.MIN_VALUE;
+        lastMovingKnownLocationTime = 0L;
+        lastMovingKnownLocationWorld = null;
+        lastServerPositionJumpTime = 0L;
+        lastServerPositionJumpFromWorld = null;
+        lastServerPositionJumpToWorld = null;
+        lastServerPositionJumpRecoveryUsedTime = 0L;
+        lastTeleportCommandTime = 0L;
+        lastTeleportCommand = "none";
+        lastTeleportCommandWorld = null;
+        lastTeleportResyncMovingDataKey = 0L;
+        lastTeleportResyncRequestTime = 0L;
+        lastTeleportResyncAppliedKey = 0L;
+        lastTeleportResyncReason = "none";
+        lastTeleportResyncWorld = null;
+        lastTeleportResyncDroppedPacketLogTime = 0L;
+        lastTeleportResyncDroppedPacketCount = 0;
+        lastTeleportResyncPendingDropLogCount = 0;
+    }
+
+    private String describeTeleportResyncState(final long now, final Location knownLocation) {
+        return NetDiagnostics.formatTeleportResyncState(lastTeleportResyncMovingDataKey,
+                lastTeleportResyncRequestTime, lastTeleportResyncAppliedKey, lastTeleportResyncReason,
+                lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                lastTeleportResyncYaw, lastTeleportResyncPitch,
+                lastTeleportResyncDroppedPacketCount, knownLocation, now);
+    }
+
+    private void logTeleportResyncStalePacketDrop(final Player player, final long now,
+                                                  final Location knownLocation,
+                                                  final Location packetLocation,
+                                                  final DataPacketFlying packetData,
+                                                  final String reason,
+                                                  final String action,
+                                                  final int queueSizeBeforeClear,
+                                                  final boolean forceLog) {
+        lastTeleportResyncDroppedPacketCount++;
+        lastTeleportResyncPendingDropLogCount++;
+        if (player == null || !CheckUtils.shouldLogDebugToConsole()) {
+            return;
+        }
+        // Teleport model diagnostic: Folia/ProtocolLib can deliver a short pair of old-location packets after teleport.
+        if (lastTeleportResyncDroppedPacketCount <= MOVING_TELEPORT_RESYNC_NORMAL_STALE_PACKET_LIMIT) {
+            return;
+        }
+        if (!forceLog && lastTeleportResyncDroppedPacketLogTime > 0L
+                && now - lastTeleportResyncDroppedPacketLogTime < 10000L) {
+            return;
+        }
+        final int loggedCount = lastTeleportResyncPendingDropLogCount;
+        lastTeleportResyncPendingDropLogCount = 0;
+        lastTeleportResyncDroppedPacketLogTime = now;
+        player.getServer().getLogger().info(NetDiagnostics.formatTeleportStaleDrop(player.getName(),
+                action, reason, lastTeleportResyncDroppedPacketCount, loggedCount, queueSizeBeforeClear,
+                lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                lastTeleportResyncYaw, lastTeleportResyncPitch, lastTeleportResyncRequestTime,
+                knownLocation, lastServerPositionJumpTime, lastServerPositionJumpFromX,
+                lastServerPositionJumpFromY, lastServerPositionJumpFromZ, lastTeleportCommandTime,
+                lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ,
+                packetLocation, packetData, now));
+    }
+
+    private boolean shouldLogTeleportResyncSuccessToConsole() {
+        return CheckUtils.shouldLogDebugToConsole()
+                && lastTeleportResyncDroppedPacketCount > MOVING_TELEPORT_RESYNC_NORMAL_STALE_PACKET_LIMIT;
+    }
+
+    private int getFlyingQueueSize() {
+        lock.lock();
+        try {
+            return flyingQueue.size();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean matchesPosition(final double x, final double y, final double z, final Location loc) {
+        return loc != null
+            && Math.abs(x - loc.getX()) <= MOVING_POSITION_MATCH_EPSILON
+            && Math.abs(y - loc.getY()) <= MOVING_POSITION_MATCH_EPSILON
+            && Math.abs(z - loc.getZ()) <= MOVING_POSITION_MATCH_EPSILON;
+    }
+
+    private String formatTeleportEventLocation() {
+        return lastMovingTeleportTime <= 0L ? "none"
+                : new StringBuilder(100).append(lastMovingTeleportWorld).append('@')
+                        .append(NetDiagnostics.formatStoredLocation(lastMovingTeleportX, lastMovingTeleportY, lastMovingTeleportZ, lastMovingTeleportYaw, lastMovingTeleportPitch))
+                        .toString();
+    }
+
+    private String formatOutgoingPositionLocation() {
+        return lastOutgoingPositionTime <= 0L ? "none"
+                : NetDiagnostics.formatStoredLocation(lastOutgoingPositionX, lastOutgoingPositionY, lastOutgoingPositionZ, lastOutgoingPositionYaw, lastOutgoingPositionPitch);
+    }
+
+    private String formatServerJumpFrom() {
+        return lastServerPositionJumpTime <= 0L ? "none"
+                : new StringBuilder(100).append(lastServerPositionJumpFromWorld).append('@')
+                        .append(NetDiagnostics.formatStoredLocation(lastServerPositionJumpFromX, lastServerPositionJumpFromY, lastServerPositionJumpFromZ,
+                                lastServerPositionJumpFromYaw, lastServerPositionJumpFromPitch))
+                        .toString();
+    }
+
+    private String formatServerJumpTo() {
+        return lastServerPositionJumpTime <= 0L ? "none"
+                : new StringBuilder(100).append(lastServerPositionJumpToWorld).append('@')
+                        .append(NetDiagnostics.formatStoredLocation(lastServerPositionJumpToX, lastServerPositionJumpToY, lastServerPositionJumpToZ,
+                                lastServerPositionJumpToYaw, lastServerPositionJumpToPitch))
+                        .toString();
+    }
+
+    private String formatTeleportCommandLocation() {
+        return lastTeleportCommandTime <= 0L ? "none"
+                : new StringBuilder(100).append(lastTeleportCommandWorld).append('@')
+                        .append(NetDiagnostics.formatStoredLocation(lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ,
+                                lastTeleportCommandYaw, lastTeleportCommandPitch))
+                        .toString();
+    }
+
+    private double distanceToStored(final double x, final double y, final double z, final Location loc) {
+        return loc == null ? Double.MAX_VALUE : distance(x, y, z, loc.getX(), loc.getY(), loc.getZ());
+    }
+
+    private double horizontalDistance(final double x1, final double z1, final double x2, final double z2) {
+        final double xDiff = x2 - x1;
+        final double zDiff = z2 - z1;
+        return Math.sqrt(xDiff * xDiff + zDiff * zDiff);
+    }
+
+    private double distance(final double x1, final double y1, final double z1,
+                            final double x2, final double y2, final double z2) {
+        final double xDiff = x2 - x1;
+        final double yDiff = y2 - y1;
+        final double zDiff = z2 - z1;
+        return Math.sqrt(xDiff * xDiff + yDiff * yDiff + zDiff * zDiff);
     }
     
     /**
@@ -146,6 +976,7 @@ public class NetData extends ACheckData {
         final Location knownLocation = player.getLocation();
         final MovingData mData = pData.getGenericInstance(MovingData.class);
         Object task = null;
+        // Folia compatibility: packet-level set backs must run on the player's owning region.
         task = SchedulerHelper.runSyncTaskForEntity(player, plugin, (arg) -> {
             /** Get the first set-back location that might be available */
             final Location newTo = mData.hasSetBack() ? mData.getSetBack(knownLocation) :

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetDiagnostics.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetDiagnostics.java
@@ -1,0 +1,178 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.checks.net;
+
+import org.bukkit.Location;
+
+import fr.neatmonster.nocheatplus.checks.net.model.DataPacketFlying;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
+
+/**
+ * Console-only formatting for net packet diagnostics.
+ */
+final class NetDiagnostics {
+
+    private NetDiagnostics() {}
+
+    static String formatKeepAliveState(final NetData data, final long now) {
+        final DataPacketFlying latest = data.getCurrentFlyingPacket();
+        return new StringBuilder(500)
+                .append("packetTime=").append(data.keepAlivePacketTime)
+                .append(",packetAge=").append(data.keepAlivePacketTime <= 0L ? -1L : now - data.keepAlivePacketTime)
+                .append(",previousPacketAge=").append(data.keepAlivePreviousPacketTime <= 0L ? -1L : now - data.keepAlivePreviousPacketTime)
+                .append(",delta=").append(data.keepAlivePacketDelta)
+                .append(",idAvailable=").append(data.keepAlivePacketIdAvailable)
+                .append(",idType=").append(data.keepAlivePacketIdType)
+                .append(",id=").append(data.keepAlivePacketIdAvailable ? Long.toString(data.keepAlivePacketId) : "none")
+                .append(",previousId=").append(data.keepAlivePreviousPacketIdAvailable ? Long.toString(data.keepAlivePreviousPacketId) : "none")
+                .append(",duplicateId=").append(data.keepAliveDuplicateId)
+                .append(",expectedResponse=").append(data.keepAliveExpectedResponse)
+                .append(",expectedAge=").append(data.keepAliveExpectedResponseAge)
+                .append(",outgoingSeen=").append(data.keepAliveOutgoingSeen)
+                .append(",outgoingAge=").append(data.keepAliveOutgoingPacketTime <= 0L ? -1L : now - data.keepAliveOutgoingPacketTime)
+                .append(",outgoingId=").append(data.keepAliveOutgoingPacketIdAvailable ? Long.toString(data.keepAliveOutgoingPacketId) : "none")
+                .append(",pendingOutgoing=").append(data.keepAlivePendingRequests)
+                .append(",fieldCounts=long:").append(data.keepAlivePacketLongCount).append("/int:").append(data.keepAlivePacketIntCount)
+                .append(",outgoingFieldCounts=long:").append(data.keepAliveOutgoingPacketLongCount).append("/int:").append(data.keepAliveOutgoingPacketIntCount)
+                .append(",async=").append(data.keepAlivePacketAsync)
+                .append(",thread=").append(data.keepAlivePacketThread)
+                .append(",outgoingAsync=").append(data.keepAliveOutgoingPacketAsync)
+                .append(",outgoingThread=").append(data.keepAliveOutgoingPacketThread)
+                .append(",lastSharedKeepAliveAge=").append(data.lastKeepAliveTime <= 0L ? -1L : now - data.lastKeepAliveTime)
+                .append(",teleportAges=event:").append(data.getMovingTeleportGraceAge(now))
+                .append(",outgoing:").append(data.getOutgoingPositionGraceAge(now))
+                .append(",serverJump:").append(data.getServerPositionJumpGraceAge(now))
+                .append(",command:").append(data.getTeleportCommandGraceAge(now))
+                .append(",latestFlying=").append(formatLatestFlying(latest, now))
+                .append(",matchedMoveSeq=").append(data.getLastMatchedMoveToSequence())
+                .append(",teleportQueue=").append(data.teleportQueue.getDebugState(now))
+                .toString();
+    }
+
+    static String formatTeleportResyncState(final long movingDataKey, final long requestTime,
+                                            final long appliedKey, final String reason,
+                                            final double x, final double y, final double z,
+                                            final float yaw, final float pitch,
+                                            final int droppedPackets, final Location knownLocation,
+                                            final long now) {
+        if (movingDataKey <= 0L) {
+            return "none";
+        }
+        return new StringBuilder(150)
+                .append("{key=").append(movingDataKey)
+                .append(",age=").append(requestTime <= 0L ? -1L : now - requestTime)
+                .append(",applied=").append(appliedKey == movingDataKey)
+                .append(",reason=").append(reason)
+                .append(",target=").append(formatStoredLocation(x, y, z, yaw, pitch))
+                .append(",targetToKnown=").append(formatStoredDistance(requestTime, x, y, z, knownLocation))
+                .append(",droppedPackets=").append(droppedPackets)
+                .append('}')
+                .toString();
+    }
+
+    static String formatTeleportResyncApplied(final String playerName, final String action, final String reason,
+                                              final double x, final double y, final double z,
+                                              final float yaw, final float pitch) {
+        return new StringBuilder(160)
+                .append("[NCP][NetMoving][resync] player=").append(playerName)
+                .append(" action=").append(action)
+                .append(" reason=").append(reason == null ? "unknown" : reason)
+                .append(" target=").append(formatStoredLocation(x, y, z, yaw, pitch))
+                .toString();
+    }
+
+    static String formatTeleportStaleDrop(final String playerName, final String action, final String reason,
+                                          final int droppedPackets, final int loggedCount,
+                                          final int queueSizeBeforeClear,
+                                          final double targetX, final double targetY, final double targetZ,
+                                          final float targetYaw, final float targetPitch,
+                                          final long targetTime, final Location knownLocation,
+                                          final long serverJumpTime, final double serverJumpFromX,
+                                          final double serverJumpFromY, final double serverJumpFromZ,
+                                          final long commandTime, final double commandX,
+                                          final double commandY, final double commandZ,
+                                          final Location packetLocation, final DataPacketFlying packetData,
+                                          final long now) {
+        return new StringBuilder(420)
+                .append("[NCP][NetMoving][stale-drop] player=").append(playerName)
+                .append(" action=").append(action)
+                .append(" reason=").append(reason == null ? "unknown" : reason)
+                .append(" droppedPackets=").append(droppedPackets)
+                .append(" loggedCount=").append(loggedCount)
+                .append(" queueSizeBeforeClear=").append(queueSizeBeforeClear)
+                .append(" target=").append(formatStoredLocation(targetX, targetY, targetZ, targetYaw, targetPitch))
+                .append(" targetToKnown=").append(formatStoredDistance(targetTime, targetX, targetY, targetZ, knownLocation))
+                .append(" packetToServerJumpFrom=").append(formatStoredDistance(serverJumpTime,
+                        serverJumpFromX, serverJumpFromY, serverJumpFromZ, packetLocation))
+                .append(" packetToCommand=").append(formatStoredDistance(commandTime, commandX, commandY, commandZ, packetLocation))
+                .append(" packet=").append(formatPacket(packetData, now))
+                .toString();
+    }
+
+    static String formatStoredLocation(final double x, final double y, final double z, final float yaw, final float pitch) {
+        return new StringBuilder(90)
+                .append("x=").append(StringUtil.fdec3.format(x))
+                .append(",y=").append(StringUtil.fdec3.format(y))
+                .append(",z=").append(StringUtil.fdec3.format(z))
+                .append(",yaw=").append(StringUtil.fdec3.format(yaw))
+                .append(",pitch=").append(StringUtil.fdec3.format(pitch))
+                .toString();
+    }
+
+    static String formatStoredDistance(final long storedTime, final double x, final double y, final double z, final Location loc) {
+        if (storedTime <= 0L || loc == null) {
+            return "none";
+        }
+        final double xDiff = loc.getX() - x;
+        final double yDiff = loc.getY() - y;
+        final double zDiff = loc.getZ() - z;
+        return new StringBuilder(80)
+                .append("h=").append(StringUtil.fdec3.format(Math.sqrt(xDiff * xDiff + zDiff * zDiff)))
+                .append("/y=").append(StringUtil.fdec3.format(Math.abs(yDiff)))
+                .append("/total=").append(StringUtil.fdec3.format(Math.sqrt(xDiff * xDiff + yDiff * yDiff + zDiff * zDiff)))
+                .toString();
+    }
+
+    static String formatPacket(final DataPacketFlying packetData, final long now) {
+        if (packetData == null) {
+            return "none";
+        }
+        return new StringBuilder(120)
+                .append("seq=").append(packetData.getSequence())
+                .append(",age=").append(now - packetData.time)
+                .append(",type=").append(packetData.getSimplifiedContentType())
+                .append(",tracked=").append(packetData.isTracked())
+                .append(",ground=").append(packetData.onGround)
+                .append(",hCollision=").append(packetData.horizontalCollision)
+                .append(",hasPos=").append(packetData.hasPos)
+                .toString();
+    }
+
+    private static String formatLatestFlying(final DataPacketFlying latest, final long now) {
+        if (latest == null) {
+            return "none";
+        }
+        return new StringBuilder(160)
+                .append("seq=").append(latest.getSequence())
+                .append(",age=").append(now - latest.time)
+                .append(",tracked=").append(latest.isTracked())
+                .append(",type=").append(latest.getSimplifiedContentType())
+                .append(",ground=").append(latest.onGround)
+                .append(",hcollide=").append(latest.horizontalCollision)
+                .append(",hasPos=").append(latest.hasPos)
+                .append(",hasLook=").append(latest.hasLook)
+                .toString();
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/model/TeleportQueue.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/model/TeleportQueue.java
@@ -103,6 +103,34 @@ public class TeleportQueue {
     }
 
     /**
+     * Compact diagnostic snapshot for NET_MOVING false-positive analysis.
+     */
+    public String getDebugState(final long now) {
+        final StringBuilder builder = new StringBuilder(300);
+        lock.lock();
+        builder.append("expectOutgoing=").append(expectOutgoing == null ? "none" : expectOutgoing.toString());
+        builder.append(",expectIncomingSize=").append(expectIncoming.size());
+        if (!expectIncoming.isEmpty()) {
+            builder.append(",incomingFirst=").append(formatCountable(expectIncoming.getFirst(), now));
+            builder.append(",incomingLast=").append(formatCountable(expectIncoming.getLast(), now));
+        }
+        builder.append(",lastAck=").append(lastAck == null ? "none" : formatCountable(lastAck, now));
+        builder.append(",ackRef=lastOutgoing:").append(lastAckReference.lastOutgoingId)
+                .append("/maxConfirmed:").append(lastAckReference.maxConfirmedId);
+        builder.append(",maxAge=").append(maxAge);
+        lock.unlock();
+        return builder.toString();
+    }
+
+    private String formatCountable(final CountableLocation ref, final long now) {
+        final StringBuilder builder = new StringBuilder(160);
+        builder.append(ref.toString());
+        builder.append(",age=");
+        builder.append(now >= ref.time ? now - ref.time : -(ref.time - now));
+        return builder.toString();
+    }
+
+    /**
      * Call for Bukkit events (expect this packet to be sent).<br>
      * TODO: The method name is misleading, as this also should be called with
      * expected outgoing packet.
@@ -243,6 +271,23 @@ public class TeleportQueue {
         }
         lock.unlock();
         return ackState;
+    }
+
+    /**
+     * Accept a movement packet that matches the teleport location from a Bukkit
+     * event before ProtocolLib has observed the matching outgoing position.
+     */
+    public boolean consumeExpectedOutgoingPosition(final DataPacketFlying packetData) {
+        if (packetData == null || !packetData.hasPos) {
+            return false;
+        }
+        lock.lock();
+        final boolean match = expectOutgoing != null && expectOutgoing.isSamePos(packetData);
+        if (match) {
+            expectOutgoing = null;
+        }
+        lock.unlock();
+        return match;
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/SchedulerHelper.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/SchedulerHelper.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
+import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.plugin.Plugin;
@@ -31,6 +32,7 @@ import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 /**
  * Utility class to provide compatibility with Paper's regionized, multi-threaded server implementation (a.k.a.: Folia), using reflection.
  * If the server is not running Folia, use Bukkit's scheduler.
+ * Keep Folia-specific calls here so the rest of NCP can stay source-compatible with regular Bukkit/Paper APIs.
  */
 public class SchedulerHelper {
 
@@ -39,12 +41,118 @@ public class SchedulerHelper {
     private static final Class<?> GlobalRegionScheduler = ReflectionUtil.getClass("io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler");
     private static final Class<?> EntityScheduler = ReflectionUtil.getClass("io.papermc.paper.threadedregions.scheduler.EntityScheduler");
     private static final boolean isFoliaServer = RegionizedServer && GlobalRegionScheduler != null && EntityScheduler != null; // && AsyncScheduler != null
+    private static final Method Bukkit_isOwnedByCurrentRegionLocation = ReflectionUtil.getMethod(Bukkit.class, "isOwnedByCurrentRegion", Location.class);
+    private static final Method Bukkit_isOwnedByCurrentRegionLocationRadius = ReflectionUtil.getMethod(Bukkit.class, "isOwnedByCurrentRegion", Location.class, int.class);
+    private static final Method Bukkit_isOwnedByCurrentRegionWorldChunk = ReflectionUtil.getMethod(Bukkit.class, "isOwnedByCurrentRegion", World.class, int.class, int.class);
+    private static final Method Bukkit_isOwnedByCurrentRegionWorldChunkRadius = ReflectionUtil.getMethod(Bukkit.class, "isOwnedByCurrentRegion", World.class, int.class, int.class, int.class);
+    private static final Method Bukkit_isOwnedByCurrentRegionEntity = ReflectionUtil.getMethod(Bukkit.class, "isOwnedByCurrentRegion", Entity.class);
     
     /**
      * @return Whether the server is running Folia
      */
     public static boolean isFoliaServer() {
         return isFoliaServer;
+    }
+
+    /**
+     * Check whether the current Folia region owns a Bukkit location before
+     * touching world/block state. Non-Folia servers keep the old behavior.
+     *
+     * @param location The block/world location to check.
+     * @return True if the location is safe to access on the current thread.
+     */
+    public static boolean isOwnedByCurrentRegion(final Location location) {
+        return isOwnedByCurrentRegion(location, 0);
+    }
+
+    /**
+     * Check whether the current Folia region owns a location and a square chunk
+     * radius around it. Use this before code that scans neighboring blocks.
+     *
+     * @param location The block/world location to check.
+     * @param squareRadiusChunks Radius in chunks, not squared distance.
+     * @return True if the area is safe to access on the current thread.
+     */
+    public static boolean isOwnedByCurrentRegion(final Location location, final int squareRadiusChunks) {
+        if (!isFoliaServer) {
+            return true;
+        }
+        if (location == null || location.getWorld() == null) {
+            return false;
+        }
+        if (squareRadiusChunks > 0 && Bukkit_isOwnedByCurrentRegionLocationRadius != null) {
+            return invokeOwnershipCheck(Bukkit_isOwnedByCurrentRegionLocationRadius, location, squareRadiusChunks);
+        }
+        if (squareRadiusChunks == 0 && Bukkit_isOwnedByCurrentRegionLocation != null) {
+            return invokeOwnershipCheck(Bukkit_isOwnedByCurrentRegionLocation, location);
+        }
+        return isOwnedByCurrentRegion(location.getWorld(), location.getBlockX(), location.getBlockZ(), squareRadiusChunks);
+    }
+
+    /**
+     * Check whether the current Folia region owns the chunk containing a block.
+     *
+     * @param world The world to check.
+     * @param blockX The block x coordinate.
+     * @param blockZ The block z coordinate.
+     * @return True if the block is safe to access on the current thread.
+     */
+    public static boolean isOwnedByCurrentRegion(final World world, final int blockX, final int blockZ) {
+        return isOwnedByCurrentRegion(world, blockX, blockZ, 0);
+    }
+
+    /**
+     * Check whether the current Folia region owns the chunk containing a block,
+     * plus an optional square chunk radius.
+     *
+     * @param world The world to check.
+     * @param blockX The block x coordinate.
+     * @param blockZ The block z coordinate.
+     * @param squareRadiusChunks Radius in chunks, not squared distance.
+     * @return True if the block area is safe to access on the current thread.
+     */
+    public static boolean isOwnedByCurrentRegion(final World world, final int blockX, final int blockZ, final int squareRadiusChunks) {
+        if (!isFoliaServer) {
+            return true;
+        }
+        if (world == null) {
+            return false;
+        }
+        final int chunkX = blockX >> 4;
+        final int chunkZ = blockZ >> 4;
+        if (squareRadiusChunks > 0 && Bukkit_isOwnedByCurrentRegionWorldChunkRadius != null) {
+            return invokeOwnershipCheck(Bukkit_isOwnedByCurrentRegionWorldChunkRadius, world, chunkX, chunkZ, squareRadiusChunks);
+        }
+        if (Bukkit_isOwnedByCurrentRegionWorldChunk != null) {
+            return invokeOwnershipCheck(Bukkit_isOwnedByCurrentRegionWorldChunk, world, chunkX, chunkZ);
+        }
+        return false;
+    }
+
+    /**
+     * Check whether the current Folia region owns an entity before reading
+     * entity state or nearby entities.
+     *
+     * @param entity The entity to check.
+     * @return True if the entity is safe to access on the current thread.
+     */
+    public static boolean isOwnedByCurrentRegion(final Entity entity) {
+        if (!isFoliaServer) {
+            return true;
+        }
+        if (entity == null || Bukkit_isOwnedByCurrentRegionEntity == null) {
+            return false;
+        }
+        return invokeOwnershipCheck(Bukkit_isOwnedByCurrentRegionEntity, entity);
+    }
+
+    private static boolean invokeOwnershipCheck(final Method method, final Object... arguments) {
+        try {
+            return Boolean.TRUE.equals(method.invoke(null, arguments));
+        }
+        catch (Throwable t) {
+            return false;
+        }
     }
     
     /**
@@ -58,6 +166,7 @@ public class SchedulerHelper {
         if (!isFoliaServer) {
             return Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> run.accept(null)).getTaskId();
         }
+        // Folia async scheduler signatures have moved across builds; these callers already do async-safe work.
         //try {
         //    Method getSchedulerMethod = ReflectionUtil.getMethodNoArgs(Server.class, "getAsyncScheduler", AsyncScheduler);
         //    Object asyncScheduler = getSchedulerMethod.invoke(Bukkit.getServer());
@@ -71,8 +180,7 @@ public class SchedulerHelper {
         //catch (Exception e) {
             // Second attempt, should be happening during onDisable calling from BukkitLogNodeDispatcher
             Thread thread = Executors.defaultThreadFactory().newThread(() -> run.accept(null));
-            if (thread == null) return null;
-            thread.run();
+            thread.start();
             return thread;
         //}
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BridgeHealth.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BridgeHealth.java
@@ -41,7 +41,7 @@ import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
  * @author asofold
  *
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 public class BridgeHealth {
 
     // TODO: Move to (smaller?) IGenericInstanceHandle instances.
@@ -326,7 +326,7 @@ public class BridgeHealth {
         }
     }
 
-    public static EntityDamageEvent getEntityDamageEvent(final Entity entity, 
+    public static EntityDamageEvent getEntityDamageEvent(final Entity entity,
             final DamageCause damageCause, final double damage) {
         try{
             return new EntityDamageEvent(entity, damageCause, damage);
@@ -341,6 +341,10 @@ public class BridgeHealth {
             }
             return null;
         }
+    }
+
+    public static void setLastDamageCause(final Entity entity, final EntityDamageEvent event) {
+        entity.setLastDamageCause(event);
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/DefaultGenericInstanceRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/DefaultGenericInstanceRegistry.java
@@ -242,31 +242,36 @@ public class DefaultGenericInstanceRegistry implements GenericInstanceRegistry, 
     @SuppressWarnings("unchecked")
     private <T> Registration<T> createEmptyRegistration(Class<T> registeredFor) {
         lock.lock();
-        Registration<T> registration = (Registration<T>) registrations.get(registeredFor); // Re-check.
-        if (registration == null) {
-            try {
+        try {
+            Registration<T> registration = (Registration<T>) registrations.get(registeredFor); // Re-check.
+            if (registration == null) {
                 // TODO: Consider individual locks / configuration for it.
                 registration = new Registration<T>(registeredFor, null, this, this, lock);
                 this.registrations.put(registeredFor, registration);
             }
-            catch (Throwable t) {
-                lock.unlock();
-                throw new IllegalArgumentException(t); // Might document.
-            }
+            return registration;
         }
-        lock.unlock();
-        return registration;
+        catch (Throwable t) {
+            throw new IllegalArgumentException(t); // Might document.
+        }
+        finally {
+            lock.unlock();
+        }
     }
 
     @Override
     public <T> void unregisterGenericInstanceRegistryListener(Class<T> registeredFor, IGenericInstanceRegistryListener<T> listener) {
         lock.lock();
-        // (Include getRegistration, as no object creation is involved.)
-        Registration<T> registration = getRegistration(registeredFor, false);
-        if (registration != null) {
-            registration.unregisterListener(listener);
+        try {
+            // (Include getRegistration, as no object creation is involved.)
+            Registration<T> registration = getRegistration(registeredFor, false);
+            if (registration != null) {
+                registration.unregisterListener(listener);
+            }
         }
-        lock.lock();
+        finally {
+            lock.unlock();
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -82,6 +82,9 @@ public abstract class ConfPaths {
     private static final String LOGGING                                  = "logging.";
     public static final String  LOGGING_ACTIVE                           = LOGGING + SUB_ACTIVE;
     public static final String  LOGGING_MAXQUEUESIZE                     = LOGGING + "max-queue-size";
+    private static final String LOGGING_DEBUG_SECTION                    = LOGGING + "debug.";
+    /** Toggle for custom verbose diagnostic lines such as [NCP][SurvivalFly][detail]. */
+    public static final String  LOGGING_DEBUG_TO_CONSOLE                 = LOGGING_DEBUG_SECTION + "to-console";
 
     private static final String LOGGING_BACKEND                          = LOGGING + "backend.";
     private static final String LOGGING_BACKEND_CONSOLE                  = LOGGING_BACKEND + "console.";
@@ -629,6 +632,8 @@ public abstract class ConfPaths {
     private static final String MOVING_SURVIVALFLY_EXTENDED                 = MOVING_SURVIVALFLY + "extended.";
     public static final String MOVING_SURVIVALFLY_EXTENDED_RESETITEM        = MOVING_SURVIVALFLY_EXTENDED + "reset-activeitem";
     public static final String MOVING_SURVIVALFLY_EXTENDED_STRICT_HORIZONTAL_PREDICTION = MOVING_SURVIVALFLY_EXTENDED + "strict-speed-prediction";
+    private static final String MOVING_SURVIVALFLY_ELYTRA                   = MOVING_SURVIVALFLY + "elytra.";
+    public static final String MOVING_SURVIVALFLY_ELYTRA_ENFORCE            = MOVING_SURVIVALFLY_ELYTRA + "enforce";
     private static final String MOVING_SURVIVALFLY_LENIENCY                 = MOVING_SURVIVALFLY + "leniency.";
     public static final String MOVING_SURVIVALFLY_LENIENCY_FREEZECOUNT      = MOVING_SURVIVALFLY_LENIENCY + "freeze-count";
     public static final String MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR      = MOVING_SURVIVALFLY_LENIENCY + "freeze-inair";
@@ -646,6 +651,7 @@ public abstract class ConfPaths {
     @GlobalConfig
     public static final String  MOVING_SURVIVALFLY_HOVER                    = MOVING_SURVIVALFLY + "hover.";
     public static final String  MOVING_SURVIVALFLY_HOVER_CHECK              = MOVING_SURVIVALFLY_HOVER + SUB_ACTIVE;
+    public static final String  MOVING_SURVIVALFLY_HOVER_ELYTRA_ENFORCE     = MOVING_SURVIVALFLY_HOVER + "elytra-enforce";
     public static final String  MOVING_SURVIVALFLY_HOVER_STEP               = MOVING_SURVIVALFLY_HOVER + "step";
     public static final String  MOVING_SURVIVALFLY_HOVER_TICKS              = MOVING_SURVIVALFLY_HOVER + "ticks";
     public static final String  MOVING_SURVIVALFLY_HOVER_LOGINTICKS         = MOVING_SURVIVALFLY_HOVER + "login-ticks";

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -50,13 +50,16 @@ public class DefaultConfig extends ConfigFile {
         //        not set(ConfPaths.CONFIGVERSION_SAVED, -1);
         set(ConfPaths.LOGGING_ACTIVE, true, 154);
         set(ConfPaths.LOGGING_MAXQUEUESIZE, 5000, 154);
+        // Compatibility diagnostics are opt-in because the extra movement/Folia details are too noisy for normal servers.
+        set(ConfPaths.LOGGING_DEBUG_TO_CONSOLE, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_STATUS, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_COMMANDS_ACTIONS, false, 1090);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_DEBUG, true, 154);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_DEBUGONLY, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_TRACE, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_NOTIFY, false, 154);
-        set(ConfPaths.LOGGING_BACKEND_CONSOLE_ACTIVE, true, 154);
+        // Default console backend off: server owners can opt in to console logging when debugging false positives.
+        set(ConfPaths.LOGGING_BACKEND_CONSOLE_ACTIVE, false, 154);
         set(ConfPaths.LOGGING_BACKEND_CONSOLE_ASYNCHRONOUS, true, 154);
         set(ConfPaths.LOGGING_BACKEND_FILE_ACTIVE, true, 154);
         set(ConfPaths.LOGGING_BACKEND_FILE_PREFIX, "", 154);
@@ -121,7 +124,8 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.BLOCKBREAK_FASTBREAK_STRICT, true, 154);
         set(ConfPaths.BLOCKBREAK_FASTBREAK_DELAY, 10, 154); 
         set(ConfPaths.BLOCKBREAK_FASTBREAK_MOD_SURVIVAL, 100, 154);
-        set(ConfPaths.BLOCKBREAK_FASTBREAK_GRACE, 500, 154);
+        // False-positive tuning: modern/Folia block-dig timing can need a larger grace, but keep it configurable.
+        set(ConfPaths.BLOCKBREAK_FASTBREAK_GRACE, 2000, 154);
         set(ConfPaths.BLOCKBREAK_FASTBREAK_ACTIONS, "cancel vl>5 cancel log:fastbreak:4:2:i vl>50 cancel log:fastbreak:0:2:if cmdc:kickfastbreak:2:5", 154);
         // Frequency
         set(ConfPaths.BLOCKBREAK_FREQUENCY_CHECK, "default", 154);
@@ -479,6 +483,8 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_SURVIVALFLY_STEPHEIGHT, "default", 154);
         set(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_RESETITEM, true, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_STRICT_HORIZONTAL_PREDICTION, true, 154);
+        // Elytra model collection: keep false while tuning from flightTrace/detail logs to avoid setback deaths.
+        set(ConfPaths.MOVING_SURVIVALFLY_ELYTRA_ENFORCE, false, 154);
         // SurvivalFly - ViolationFrequencyHook
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_ACTIVE, true, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_DEBUG, false, 154);
@@ -496,6 +502,8 @@ public class DefaultConfig extends ConfigFile {
             + " vl>2100 cancel log:survivalflyhighvl:0:4:icf cmdc:kickfly:0:15", 154);     
         // SurvivalFly - Hover Subcheck
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_CHECK, true, 154); // Not a check type yet.
+        // Elytra hover model telemetry stays data-only by default until server owners opt into enforcement.
+        set(ConfPaths.MOVING_SURVIVALFLY_HOVER_ELYTRA_ENFORCE, false, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_STEP, 5, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_TICKS, 85, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_LOGINTICKS, 60, 154);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/Permissions.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/Permissions.java
@@ -58,6 +58,7 @@ public class Permissions {
 
     // Notifications (in-game).
     public static final RegisteredPermission  NOTIFY                       = add(NOCHEATPLUS + ".notify");
+    public static final RegisteredPermission  COMPAT_BEDROCK              = add(NOCHEATPLUS + ".compat.bedrock");
 
     // Command permissions.
     public static final RegisteredPermission  COMMAND                      = add(NOCHEATPLUS + ".command");

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/CheckUtils.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/CheckUtils.java
@@ -28,6 +28,8 @@ import fr.neatmonster.nocheatplus.checks.fight.FightData;
 import fr.neatmonster.nocheatplus.checks.inventory.InventoryData;
 import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
 import fr.neatmonster.nocheatplus.components.concurrent.IPrimaryThreadContextTester;
+import fr.neatmonster.nocheatplus.config.ConfigManager;
+import fr.neatmonster.nocheatplus.config.ConfPaths;
 import fr.neatmonster.nocheatplus.logging.StaticLog;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
@@ -76,6 +78,11 @@ public class CheckUtils {
             improperAsynchronousAPIAccess(checkType);
             return false;
         }
+    }
+
+    public static boolean shouldLogDebugToConsole() {
+        // This gates the extra diagnostic console spam added for compatibility tuning, not the normal NCP backend loggers.
+        return ConfigManager.getConfigFile().getBoolean(ConfPaths.LOGGING_DEBUG_TO_CONSOLE, false);
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/CollisionUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/CollisionUtil.java
@@ -1012,14 +1012,14 @@ public class CollisionUtil {
                         continue;
                     }
                     // how many of the current block’s coordinates (x, y, z) lie on the edges of the search region defined by the entity’s AABB
-                    //int edgeCount = ((x == minBlockX || x == maxBlockX) ? 1 : 0) +
-                    //                ((y == minBlockY || y == maxBlockY) ? 1 : 0) +
-                    //                ((z == minBlockZ || z == maxBlockZ) ? 1 : 0);
-                    //if (edgeCount != 3 && (edgeCount != 1 || (BlockFlags.getBlockFlags(mat) & BlockFlags.F_HEIGHT150) != 0) 
-                    //    && (edgeCount != 2 || mat == BridgeMaterial.MOVING_PISTON)) {
+                    int edgeCount = ((x == minBlockX || x == maxBlockX) ? 1 : 0) +
+                                    ((y == minBlockY || y == maxBlockY) ? 1 : 0) +
+                                    ((z == minBlockZ || z == maxBlockZ) ? 1 : 0);
+                    if (edgeCount != 3 && (edgeCount != 1 || (BlockFlags.getBlockFlags(mat) & BlockFlags.F_HEIGHT150) != 0) 
+                        && (edgeCount != 2 || mat == BridgeMaterial.MOVING_PISTON)) {
                         // Don't add to a list if we only care if the player intersects with the block
                         if (!onlyCheckCollide) {
-                            final double[] originAABB = blockCache.getBounds(x, y, z);
+                            final double[] originAABB = blockCache.fetchBounds(x, y, z);
                             if (originAABB != null) {
                                 final double[] multiAABB = AxisAlignedBBUtils.move(originAABB, x, y, z);
                                 collisionBoxes.addAll(AxisAlignedBBUtils.splitIntoSingle(multiAABB));
@@ -1028,7 +1028,7 @@ public class CollisionUtil {
                         else if (AxisAlignedBBUtils.isCollided(blockCache.getBounds(x, y, z), x, y, z, entityAABB, true)) {
                             return true;
                         }
-                    //}
+                    }
                 }
             }
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/PlayerLocation.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/PlayerLocation.java
@@ -202,29 +202,28 @@ public class PlayerLocation extends RichEntityLocation {
             }
         }
         else {
-            final double signumX = Math.signum(xDistance) * 0.05D;
-            final double signumZ = Math.signum(zDistance) * 0.05D;
-            double[] offsetAABB_X = new double[]{minX + xDistance, minY + yBelow - 1.0E-5F, minZ, maxX + xDistance, minY, maxZ}; // Skip using maxY, as we do not care of the top of the box in this case.
-            while (xDistance != 0.0D && CollisionUtil.isEmpty(blockCache, player, offsetAABB_X)) {
+            double signumX = Math.signum(xDistance) * 0.05D;
+            double signumZ;
+            double[] offsetAABB_X = new double[]{minX + xDistance, minY + yBelow - 9.999999747378752E-6D, minZ, maxX + xDistance, minY, maxZ}; // Skip using maxY, as we do not care of the top of the box in this case.
+            for (signumZ = Math.signum(zDistance) * 0.05D; xDistance != 0.0D && CollisionUtil.isEmpty(blockCache, player, offsetAABB_X); xDistance -= signumX) {
                 if (Math.abs(xDistance) <= 0.05D) {
                     xDistance = 0.0D;
                     break;
                 }
-                xDistance -= signumX;
-                offsetAABB_X = new double[]{minX + xDistance, minY + yBelow - 1.0E-5F, minZ, maxX + xDistance, minY, maxZ};
+                offsetAABB_X = new double[]{minX + xDistance, minY + yBelow - 9.999999747378752E-6D, minZ, maxX + xDistance, minY, maxZ};
             }
             
-            double[] offsetAABB_Z = new double[]{minX, minY + yBelow - 1.0E-5F, minZ + zDistance, maxX, minY, maxZ + zDistance};
+            double[] offsetAABB_Z = new double[]{minX, minY + yBelow - 9.999999747378752E-6D, minZ + zDistance, maxX, minY, maxZ + zDistance};
             while (zDistance != 0.0D && CollisionUtil.isEmpty(blockCache, player, offsetAABB_Z)) {
                 if (Math.abs(zDistance) <= 0.05D) {
                     zDistance = 0.0D;
                     break;
                 }
                 zDistance -= signumZ;
-                offsetAABB_Z = new double[]{minX, minY + yBelow - 1.0E-5F, minZ + zDistance, maxX, minY, maxZ + zDistance};
+                offsetAABB_Z = new double[]{minX, minY + yBelow - 9.999999747378752E-6D, minZ + zDistance, maxX, minY, maxZ + zDistance};
             }
             
-            double[] offsetAABB_XZ = new double[]{minX + xDistance, minY + yBelow - 1.0E-5F, minZ + zDistance, maxX + xDistance, minY, maxZ + zDistance};
+            double[] offsetAABB_XZ = new double[]{minX + xDistance, minY + yBelow - 9.999999747378752E-6D, minZ + zDistance, maxX + xDistance, minY, maxZ + zDistance};
             while (xDistance != 0.0D && zDistance != 0.0D && CollisionUtil.isEmpty(blockCache, player, offsetAABB_XZ)) {
                 if (Math.abs(xDistance) <= 0.05D) {
                     xDistance = 0.0D;
@@ -235,7 +234,7 @@ public class PlayerLocation extends RichEntityLocation {
                     zDistance = 0.0D;
                 } 
                 else zDistance -= signumZ;
-                offsetAABB_XZ = new double[]{minX + xDistance, minY + yBelow - 1.0E-5F, minZ + zDistance, maxX + xDistance, minY, maxZ + zDistance};
+                offsetAABB_XZ = new double[]{minX + xDistance, minY + yBelow - 9.999999747378752E-6D, minZ + zDistance, maxX + xDistance, minY, maxZ + zDistance};
             }
         }
         vector = new Vector(xDistance, 0.0, zDistance);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
@@ -3760,6 +3760,66 @@ public class BlockProperties {
     }
 
     /**
+     * Check if the given bounding box collides with waterlogged blocks.
+     *
+     * <p>Folia support: waterlogged state now comes through {@link BlockCache}
+     * extended data, so callers keep the old API without directly querying
+     * Bukkit block data from a movement check.</p>
+     *
+     * @param world
+     *            the world
+     * @param access
+     *            the access
+     * @param minX
+     *            the min x
+     * @param minY
+     *            the min y
+     * @param minZ
+     *            the min z
+     * @param maxX
+     *            the max x
+     * @param maxY
+     *            the max y
+     * @param maxZ
+     *            the max z
+     * @return true, if successful
+     */
+    public static final boolean isWaterlogged(final World world, final BlockCache access,
+                                              final double minX, final double minY, final double minZ,
+                                              final double maxX, final double maxY, final double maxZ) {
+        if (!Bridge1_13.hasIsSwimming()) {
+            return false;
+        }
+        final int iMinX = Location.locToBlock(minX);
+        final int iMaxX = Location.locToBlock(maxX);
+        final int iMinY = Location.locToBlock(minY);
+        final int iMaxY = Math.min(Location.locToBlock(maxY), access.getMaxBlockY());
+        final int iMinZ = Location.locToBlock(minZ);
+        final int iMaxZ = Location.locToBlock(maxZ);
+
+        for (int x = iMinX; x <= iMaxX; x++) {
+            for (int z = iMinZ; z <= iMaxZ; z++) {
+                for (int y = iMaxY; y >= iMinY; y--) {
+                    if ((access.getExtendedData(x, y, z) & BlockFlags.F_WATERLOGGED) == 0) {
+                        continue;
+                    }
+                    // Waterlogged blocks expose the water volume inside the block cache.
+                    if (minX > 1.0 + x || maxX < 0.0 + x
+                        || minY > LIQUID_HEIGHT_LOWERED + y || maxY < 0.0 + y
+                        || minZ > 1.0 + z || maxZ < 0.0 + z) {
+                        continue;
+                    }
+                    if (minX == 1.0 + x || minY == LIQUID_HEIGHT_LOWERED + y || minZ == 1.0 + z) {
+                        continue;
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Test if the box collide with any block that matches the flags somehow.
      * Convenience method.
      *

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/moving/AuxMoving.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/moving/AuxMoving.java
@@ -27,6 +27,7 @@ import fr.neatmonster.nocheatplus.checks.moving.MovingData;
 import fr.neatmonster.nocheatplus.checks.moving.model.PlayerMoveInfo;
 import fr.neatmonster.nocheatplus.checks.moving.model.VehicleMoveInfo;
 import fr.neatmonster.nocheatplus.compat.MCAccess;
+import fr.neatmonster.nocheatplus.compat.SchedulerHelper;
 import fr.neatmonster.nocheatplus.components.registry.event.IGenericInstanceHandle;
 import fr.neatmonster.nocheatplus.components.registry.feature.IRegisterAsGenericInstance;
 
@@ -111,6 +112,11 @@ public class AuxMoving implements IRegisterAsGenericInstance {
      * @param cc
      */
     public synchronized void resetPositionsAndMediumProperties(final Player player, final Location loc, final MovingData data, final MovingConfig cc) {
+        if (!SchedulerHelper.isOwnedByCurrentRegion(loc, 1)) {
+            data.clearMostMovingCheckData();
+            data.setSetBack(loc);
+            return;
+        }
         final PlayerMoveInfo moveInfo = usePlayerMoveInfo();
         moveInfo.set(player, loc, null, cc.yOnGround);
         data.resetPlayerPositions(moveInfo.from);
@@ -130,6 +136,11 @@ public class AuxMoving implements IRegisterAsGenericInstance {
      * @param cc
      */
     public synchronized void resetVehiclePositions(final Entity vehicle, final Location vehicleLocation, final MovingData data, final MovingConfig cc) {
+        if (!SchedulerHelper.isOwnedByCurrentRegion(vehicle) || !SchedulerHelper.isOwnedByCurrentRegion(vehicleLocation, 1)) {
+            data.clearVehicleData();
+            data.clearVehicleMorePacketsData();
+            return;
+        }
         final VehicleMoveInfo vMoveInfo = useVehicleMoveInfo();
         vMoveInfo.set(vehicle, vehicleLocation, null, cc.yOnGround);
         data.resetVehiclePositions(vMoveInfo.from);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/moving/MovingUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/moving/MovingUtil.java
@@ -364,8 +364,20 @@ public class MovingUtil {
         return 1.0 + amplifier;
     }
 
+    private static boolean canCollectFullCheckContext(final RichBoundsLocation from, final RichBoundsLocation to) {
+        if (!SchedulerHelper.isFoliaServer()) {
+            return true;
+        }
+        return SchedulerHelper.isOwnedByCurrentRegion(from.getWorld(), from.getBlockX(), from.getBlockZ(), 1)
+            && SchedulerHelper.isOwnedByCurrentRegion(to.getWorld(), to.getBlockX(), to.getBlockZ(), 1);
+    }
+
 
     public static void prepareFullCheck(final RichBoundsLocation from, final RichBoundsLocation to, final MoveData thisMove, final double yOnGround) {
+        if (!canCollectFullCheckContext(from, to)) {
+            thisMove.set(from, to);
+            return;
+        }
         // Collect block flags.
         from.collectBlockFlags(yOnGround);
         if (from.isSamePos(to)) {

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -1309,6 +1309,10 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
     private void onJoinLow(final Player player) {
         final String playerName = player.getName();
         final IPlayerData data = DataManager.getPlayerData(player);
+        data.setBedrockPlayer(isBedrockPlayer(player, data));
+        if (data.isBedrockPlayer()) {
+            logManager.info(Streams.STATUS, "Detected Bedrock player: " + playerName);
+        }
         if (data.hasPermission(Permissions.NOTIFY, player)) { // Updates the cache.
             // Login notifications...
             //            // Update available.
@@ -1334,6 +1338,32 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
                 logManager.severe(Streams.INIT, t);
             }
         }
+    }
+
+    private boolean isBedrockPlayer(final Player player, final IPlayerData data) {
+        if (data.hasPermission(Permissions.COMPAT_BEDROCK, player)) {
+            return true;
+        }
+        try {
+            final Class<?> apiClass = Class.forName("org.geysermc.floodgate.api.FloodgateApi");
+            final Object api = apiClass.getMethod("getInstance").invoke(null);
+            return Boolean.TRUE.equals(apiClass.getMethod("isFloodgatePlayer", java.util.UUID.class).invoke(api, player.getUniqueId()));
+        }
+        catch (Throwable ignored) {}
+        try {
+            final Class<?> apiClass = Class.forName("org.geysermc.geyser.api.GeyserApi");
+            final Object api = apiClass.getMethod("api").invoke(null);
+            if (api != null) {
+                try {
+                    return Boolean.TRUE.equals(apiClass.getMethod("isBedrockPlayer", java.util.UUID.class).invoke(api, player.getUniqueId()));
+                }
+                catch (NoSuchMethodException ignored) {
+                    return apiClass.getMethod("connectionByUuid", java.util.UUID.class).invoke(api, player.getUniqueId()) != null;
+                }
+            }
+        }
+        catch (Throwable ignored) {}
+        return player.getName().startsWith(".");
     }
 
     private void onLeave(final Player player) {

--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestInteractRayTracing.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestInteractRayTracing.java
@@ -15,6 +15,7 @@
 package fr.neatmonster.nocheatplus.test;
 
 import org.bukkit.Material;
+import org.junit.Before;
 import org.junit.Test;
 
 import fr.neatmonster.nocheatplus.compat.bukkit.BridgeMaterial;
@@ -43,7 +44,8 @@ public class TestInteractRayTracing extends MockServerBase {
 
     // TODO: Blunt copy and paste from TestPassableRayTracing, add something that makes sense.
 
-    public TestInteractRayTracing() {
+    @Before
+    public void initBlockProperties() {
         StaticLog.setUseLogManager(false);
         BlockTests.initBlockProperties();
         StaticLog.setUseLogManager(true);

--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestPassableRayTracing.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestPassableRayTracing.java
@@ -15,6 +15,7 @@
 package fr.neatmonster.nocheatplus.test;
 
 import org.bukkit.Material;
+import org.junit.Before;
 import org.junit.Test;
 
 import fr.neatmonster.nocheatplus.compat.bukkit.BridgeMaterial;
@@ -36,7 +37,8 @@ public class TestPassableRayTracing extends MockServerBase {
     // TODO: From ground and onto ground moves, onto-edge moves (block before edge, into block, etc).
     // TODO: Randomized tests (Collide with inner sphere, not collide with outer sphere).
 
-    public TestPassableRayTracing() {
+    @Before
+    public void initBlockProperties() {
         StaticLog.setUseLogManager(false);
         BlockTests.initBlockProperties();
         StaticLog.setUseLogManager(true);

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Links
 ###### Support and Documentation
 * [Issues/Tickets](https://github.com/Updated-NoCheatPlus/NoCheatPlus/issues)
 * [Wiki](https://github.com/Updated-NoCheatPlus/Docs)
+* [Compatibility debugging guide](docs/compat-debugging.md)
 * [Configuration](https://github.com/Updated-NoCheatPlus/Docs#configuration)
 * [Permissions](https://github.com/Updated-NoCheatPlus/Docs/blob/master/Settings/Permissions.md)
 * [Commands](https://github.com/Updated-NoCheatPlus/Docs/blob/master/Settings/Commands.md)

--- a/docs/compat-debugging.md
+++ b/docs/compat-debugging.md
@@ -1,0 +1,151 @@
+# Compatibility Debugging Guide
+
+This guide explains the extra compatibility diagnostics added for Bedrock, Folia, modern movement clients, and false-positive tuning. The goal is to make console logs easier to read without losing the detailed values needed to refine checks.
+
+## Enabling Console Detail
+
+The detailed compatibility lines are opt-in because they can be noisy on live servers. Enable them only while testing or collecting false-positive reports.
+
+Relevant config paths:
+
+```yaml
+logging:
+  debug:
+    to-console: true
+  backend:
+    console:
+      active: true
+```
+
+The normal violation/debug settings still control whether a check has enough debug context to print.
+
+## Reading A Detail Line
+
+Most new detail lines keep the same shape:
+
+```text
+[NCP][CheckName][detail] player=name subcheck=SPECIFIC_BRANCH summary=short_reason{...} ... tags=...
+```
+
+Important fields:
+
+| Field | Meaning |
+| --- | --- |
+| `subcheck` | The concrete branch behind the umbrella check name. Use this first when sorting logs. |
+| `summary` | Short human-readable diagnosis for quick scanning. This is intentionally near the front of the line. |
+| `movementMode` | SurvivalFly movement state such as `GROUND`, `WATER`, `CLIMBABLE`, `ELYTRA_GLIDING`, or `ELYTRA_FIREWORK`. |
+| `model` | The selected SurvivalFly model branch, if one matched the movement context. |
+| `hOver` | Remaining horizontal distance over the model boundary after model handling. |
+| `yOver` | Remaining vertical distance over the model boundary after model handling. |
+| `physicsModel` | Diagnostic-only gravity/velocity probe for SurvivalFly. It shows expected next fall speed, actual acceleration, server velocity differences, and horizontal-vs-vertical glide ratios. |
+| `tags` | Full diagnostic markers for deeper analysis. |
+
+## SurvivalFly Tags
+
+SurvivalFly logs are the densest because one umbrella check covers many movement states.
+
+Common tag groups:
+
+| Tag prefix | Meaning |
+| --- | --- |
+| `subcheck_` | Final readable failure type, for example `subcheck_elytra_firework_y`. |
+| `mode_` | Broad movement mode at the time of the violation. |
+| `branch_` | Important branch/context that influenced diagnosis, such as liquid, collision, velocity, or recent setback. |
+| `branch_model_` | The code selected a named movement model for this move. |
+| `model_*` | A selected model accepted part of the movement. Suffix `_h` means horizontal, `_y` means vertical. |
+| `model_*_miss` | A model was selected but did not accept the movement envelope. This is usually the next place to refine. |
+| `diag_*` | Diagnostic probe only. It marks a likely area to inspect but does not mean movement was accepted. |
+
+Example:
+
+```text
+summary=elytra_firework_y{mode=elytra_firework,model=elytra_firework,axis=y,hOver=0,yOver=0.035,tags=subcheck_elytra_firework_y+branch_elytra_state+branch_model_elytra_firework}
+```
+
+Practical reading:
+
+- The player was actively gliding with a firework.
+- The selected model was `elytra_firework`.
+- The remaining miss was vertical (`axis=y`).
+- `yOver=0.035` is the amount still outside the accepted model.
+- If this was false, refine the elytra firework vertical model, not generic SurvivalFly.
+
+## Teleport And Portal Sync
+
+Folia and modern teleport plugins can use `teleportAsync`, portal callbacks, or direct server position packets. In those cases, packet-level `NET_MOVING` may see the position jump before SurvivalFly has clean movement history for the new location.
+
+Useful tags:
+
+| Tag | Meaning |
+| --- | --- |
+| `server_position_jump_stale_packet_model` | `NET_MOVING` matched a stale pre-teleport packet to a recent server-side position jump. This is not elytra-specific. |
+| `teleport_command_stale_packet_model` | A command such as `/home` or `/rtp` was recently issued, and the old packet still fit the command-location stale-packet model. |
+| `server_position_jump_recovery_grace` | One last-resort stale packet was consumed after a server-side jump when movement history was invalid. |
+| `server_position_jump_air_resync_horizontal_model` | SurvivalFly accepted a small post-teleport air/fall horizontal mismatch using the server-position resync model. |
+| `server_position_jump_air_resync_vertical_model` | SurvivalFly accepted the next post-teleport vertical packet as a vanilla gravity continuation. |
+
+The final teleport sync model handles the common Folia/ProtocolLib packet order pattern where one or two old-location packets arrive after a command teleport, `/rtp`, `/spawn`, `/home`, respawn, or portal-style server-position jump. Those packets are deleted from packet history and do not represent player movement at the new location. Console diagnostics are intentionally quiet for that normal one-or-two-packet pattern; repeated stale packets beyond that still log so the packet ordering model can be refined.
+
+If teleport false positives remain, include the `NET_MOVING` detail, the matching `NET_MOVING][teleport]` line, and the next SurvivalFly detail line. The useful fields are `serverJumpAge`, `serverJumpFrom`, `serverJumpTo`, `serverJumpStalePacketModel`, `commandStalePacketModel`, `packetModel`, `movementMode`, `movementModel`, `modelProbe`, `summary`, and `tags`.
+
+## Folia Block Cache Fallback
+
+Folia region ownership can make direct block reads unsafe from packet or async paths. The Bukkit block cache now first checks normal region ownership, then retries with exact-location ownership before returning `AIR` or legacy data `0` as the final safe fallback.
+
+Single fallback events during teleport or chunk handoff are expected and are not printed to console. Repeated fallback events are rate-limited and logged as safe fallback diagnostics with resolved and final-fallback counts.
+
+## Other Check Summaries
+
+The other detailed checks now include short `summary` fields too:
+
+| Check | Summary shape | What it helps identify |
+| --- | --- | --- |
+| FastBreak | `summary=block_timing{...}` | Block/tool timing, missing break time, grace budget. |
+| FightAngle | `summary=angle_*{...}` | Aim angle, timing, movement, or target-switch branch. |
+| FightCritical | `summary=critical_*{...}` | Fall-distance mismatch, reset-condition criticals, jump-phase desync. |
+| BlockDirection | `summary=block_direction{...}` | Ray miss vs unreachable block face. |
+| MorePackets | `summary=packet_rate{...}` | Packet-rate or burst violations separate from movement model errors. |
+| Passable | `summary=passable_raytrace{...}` | Ray-trace branch and block types involved in stuck/inside-block flags. |
+| KeepAliveFrequency | `summary=keepalive_bucket{...}` | Bucket timing, duplicate/fast keep-alive replies, Folia async timing. |
+| NetMoving | `summary=net_moving{...}` | Extreme packet movement vs teleport/server-position stale-packet models. |
+
+## What To Include In A Bug Report
+
+When reporting a false positive, include:
+
+1. The full `[NCP][...][detail]` line, not only the short `[NC+] [VL]` line.
+2. What the player was doing in plain terms, such as "Bedrock player running up stairs" or "elytra firework into ground".
+3. Whether the player was Bedrock or Java.
+4. The block or environment involved, especially stairs, slabs, lanterns, carpet, vines, scaffolding, water, boats, or portals.
+5. A few lines before and after the flag if teleport, respawn, knockback, firework, or combat happened.
+
+For SurvivalFly false positives, the most useful first fields are:
+
+```text
+summary=...
+movementMode=...
+subcheck=...
+movementModel=...
+physicsModel=...
+modelProbe=...
+elytraModel=...
+tags=...
+```
+
+## Model vs Grace
+
+Some constants still contain `GRACE` in their names for history. In the newer model paths, those values should be treated as empirical residual boundaries inside a selected movement state.
+
+Preferred design:
+
+```text
+identify movement state -> select model -> calculate boundary -> compare actual movement
+```
+
+Avoid this design when changing future code:
+
+```text
+normal model fails -> broad grace accepts actual movement afterward
+```
+
+If a tolerance remains because packet ordering, Folia timing, teleport sync, or floating-point precision cannot be modeled exactly, document that reason next to the code.


### PR DESCRIPTION
## Summary

Improves general movement compatibility for Bedrock/Geyser/Floodgate-style clients and modern server behavior, focusing on false positives outside the main SurvivalFly/elytra model work.

## What Changed

- Improves Bedrock-aware movement handling in the moving listener path.
- Refines general movement state handling used by movement checks.
- Improves Passable and NoFall behavior around modern movement edge cases.
- Adjusts vehicle movement envelope handling to reduce false positives.
- Improves combat/block direction related compatibility paths that could false flag during normal interaction.
- Adds supporting movement utility changes used by the compatibility models.

## Why

Bedrock clients and modern server movement timing can differ from legacy Java assumptions, especially around partial-block movement, combat/velocity, vehicles, and event ordering. These changes reduce normal-player false positives without putting the larger SurvivalFly/elytra model changes into this PR.

## Notes

This is PR 4 in the stacked series.

Base branch: `block-environment-foundations`  
Head branch: `bedrock-general-movement`

This PR intentionally does **not** include the large SurvivalFly/elytra model changes. Those are isolated in the next stacked PR.
