### PR TITLE
Folia net sync

### DIFF
--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAliveAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAliveAdapter.java
@@ -44,7 +44,7 @@ public class KeepAliveAdapter extends BaseAdapter {
     private final KeepAliveFrequency frequencyCheck = new KeepAliveFrequency();
 
     public KeepAliveAdapter(Plugin plugin) {
-        super(plugin, ListenerPriority.LOW, PacketType.Play.Client.KEEP_ALIVE);
+        super(plugin, ListenerPriority.LOW, PacketType.Play.Client.KEEP_ALIVE, PacketType.Play.Server.KEEP_ALIVE);
         this.checkType = CheckType.NET_KEEPALIVEFREQUENCY;
         // Add feature tags for checks.
         if (NCPAPIProvider.getNoCheatPlusAPI().getWorldDataManager().isActiveAnywhere(CheckType.NET_KEEPALIVEFREQUENCY)) {
@@ -70,11 +70,12 @@ public class KeepAliveAdapter extends BaseAdapter {
         final IPlayerData pData = DataManager.getPlayerDataSafe(player);
         if (pData == null) return;
         final NetData data = pData.getGenericInstance(NetData.class);
+        recordKeepAlivePacketDetails(event, data, time);
         data.lastKeepAliveTime = time;
         final NetConfig cc = pData.getGenericInstance(NetConfig.class);
 
         // Run check(s).
-        // TODO: Match vs. outgoing keep alive requests.
+        // KeepAlive model: outgoing server ids are recorded in onPacketSending; matching replies are expected.
         // TODO: Better modeling of actual packet sequences (flying vs. keep alive vs. request/ping).
         // TODO: Better integration with god-mode check / trigger reset ndt.
         if (frequencyCheck.isEnabled(player, pData) 
@@ -83,8 +84,25 @@ public class KeepAliveAdapter extends BaseAdapter {
         }
     }
 
+    private void recordKeepAlivePacketDetails(final PacketEvent event, final NetData data, final long time) {
+        final KeepAlivePacketInfo info = KeepAlivePacketInfo.read(event.getPacket());
+        data.recordKeepAlivePacket(time, info.idAvailable, info.id, info.idType, info.longCount, info.intCount,
+                event.isAsync(), Thread.currentThread().getName());
+    }
+
     @Override
     public void onPacketSending(PacketEvent event) {
-        // TODO: Maybe detect if keep alive wasn't asked for + allow cancel.
+        final Player player = event.getPlayer();
+        if (player == null) {
+            return;
+        }
+        final IPlayerData pData = DataManager.getPlayerDataSafe(player);
+        if (pData == null) {
+            return;
+        }
+        final KeepAlivePacketInfo info = KeepAlivePacketInfo.read(event.getPacket());
+        pData.getGenericInstance(NetData.class).recordOutgoingKeepAlivePacket(System.currentTimeMillis(),
+                info.idAvailable, info.id, info.idType, info.longCount, info.intCount,
+                event.isAsync(), Thread.currentThread().getName());
     }
 }

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAlivePacketInfo.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAlivePacketInfo.java
@@ -1,0 +1,74 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.checks.net.protocollib;
+
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.reflect.StructureModifier;
+
+/**
+ * ProtocolLib packet-shape extraction for keepalive request/response ids.
+ */
+final class KeepAlivePacketInfo {
+
+    final boolean idAvailable;
+    final long id;
+    final String idType;
+    final int longCount;
+    final int intCount;
+
+    private KeepAlivePacketInfo(final boolean idAvailable, final long id, final String idType,
+                                final int longCount, final int intCount) {
+        this.idAvailable = idAvailable;
+        this.id = id;
+        this.idType = idType;
+        this.longCount = longCount;
+        this.intCount = intCount;
+    }
+
+    static KeepAlivePacketInfo read(final PacketContainer packet) {
+        boolean idAvailable = false;
+        long id = 0L;
+        String idType = "none";
+        int longCount = -1;
+        int intCount = -1;
+        try {
+            final StructureModifier<Long> longs = packet.getLongs();
+            longCount = longs.size();
+            if (longCount > 0) {
+                final Long value = longs.read(0);
+                if (value != null) {
+                    idAvailable = true;
+                    id = value.longValue();
+                    idType = "long";
+                }
+            }
+        }
+        catch (Throwable ignored) {}
+        try {
+            final StructureModifier<Integer> integers = packet.getIntegers();
+            intCount = integers.size();
+            if (!idAvailable && intCount > 0) {
+                final Integer value = integers.read(0);
+                if (value != null) {
+                    idAvailable = true;
+                    id = value.longValue();
+                    idType = "int";
+                }
+            }
+        }
+        catch (Throwable ignored) {}
+        return new KeepAlivePacketInfo(idAvailable, id, idType, longCount, intCount);
+    }
+}

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/OutgoingPosition.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/OutgoingPosition.java
@@ -117,6 +117,7 @@ public class OutgoingPosition extends BaseAdapter {
         }
 
         final CountableLocation packetData = data.teleportQueue.onOutgoingTeleport(x, y, z, yaw, pitch, teleportId);
+        data.recordOutgoingPosition(x, y, z, yaw, pitch, teleportId, packetData != null, time);
         if (packetData == null) {
             // Add counter for untracked (by Bukkit API) outgoing teleport.
             // TODO: There may be other cases which are indicated by Bukkit API events.

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/UseEntityAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/UseEntityAdapter.java
@@ -33,6 +33,7 @@ import fr.neatmonster.nocheatplus.checks.net.AttackFrequency;
 import fr.neatmonster.nocheatplus.checks.net.NetConfig;
 import fr.neatmonster.nocheatplus.checks.net.NetData;
 import fr.neatmonster.nocheatplus.compat.versions.ServerVersion;
+import fr.neatmonster.nocheatplus.logging.StaticLog;
 import fr.neatmonster.nocheatplus.players.DataManager;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
@@ -104,6 +105,10 @@ public class UseEntityAdapter extends BaseAdapter {
 
     private final LegacyReflectionSet legacySet;
 
+    private volatile boolean protocolLibEntityUseActionBroken = false;
+
+    private volatile boolean protocolLibEntityUseActionWarningLogged = false;
+
     public UseEntityAdapter(Plugin plugin) {
         super(plugin, PacketType.Play.Client.USE_ENTITY);
         this.checkType = CheckType.NET_ATTACKFREQUENCY;
@@ -169,17 +174,20 @@ public class UseEntityAdapter extends BaseAdapter {
         if (!packetInterpreted) {
             // Handle as if latest.
             try {
-                final StructureModifier<EntityUseAction> actions = packet.getEntityUseActions();
-                // TODO: Not sure about version!
-                if (isServerAtLeast1_13) {
-                    final StructureModifier<WrappedEnumEntityUseAction> enumActions = packet.getEnumEntityUseActions();
-                    if (enumActions.size() == 1 && enumActions.read(0).equals(WrappedEnumEntityUseAction.attack())) {
+                if (!protocolLibEntityUseActionBroken) {
+                    final StructureModifier<EntityUseAction> actions = packet.getEntityUseActions();
+                    if (actions.size() == 1) {
                         packetInterpreted = true;
-                        isAttack = true;
+                        isAttack = actions.read(0) == EntityUseAction.ATTACK;
                     }
-                } else if (actions.size() == 1 && actions.read(0) == EntityUseAction.ATTACK) {
-                    packetInterpreted = true;
-                    isAttack = true;
+                    // ProtocolLib compatibility: modern snapshots can throw while initializing enum wrappers.
+                    if (!packetInterpreted && isServerAtLeast1_13) {
+                        final StructureModifier<WrappedEnumEntityUseAction> enumActions = packet.getEnumEntityUseActions();
+                        if (enumActions.size() == 1 && enumActions.read(0).equals(WrappedEnumEntityUseAction.attack())) {
+                            packetInterpreted = true;
+                            isAttack = true;
+                        }
+                    }
                 }
             }
             catch (NullPointerException e) {
@@ -187,6 +195,16 @@ public class UseEntityAdapter extends BaseAdapter {
                  * TODO: Observed somewhere on 1_7_R4, probably a custom build -
                  * why doesn't the LegacyReflectionSet work here?
                  */
+            }
+            catch (LinkageError | RuntimeException e) {
+                protocolLibEntityUseActionBroken = true;
+                if (!protocolLibEntityUseActionWarningLogged) {
+                    protocolLibEntityUseActionWarningLogged = true;
+                    // Diagnostic logging: name the failing branch so attack/combat packet issues are clear in console.
+                    StaticLog.logWarning("ProtocolLib could not expose USE_ENTITY action data (branch=enumEntityUseActions, packet=" + packet.getType() + "). Skipping AttackFrequency interpretation for USE_ENTITY packets until restart.");
+                    StaticLog.logWarning("ProtocolLib USE_ENTITY action failure: " + e.getClass().getName() + ": " + e.getMessage());
+                }
+                return;
             }
         }
         if (!packetInterpreted) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/types/CommandAction.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/types/CommandAction.java
@@ -17,6 +17,7 @@ package fr.neatmonster.nocheatplus.actions.types;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 import fr.neatmonster.nocheatplus.actions.AbstractActionList;
@@ -63,8 +64,8 @@ public class CommandAction<D extends ParameterHolder, L extends AbstractActionLi
     @Override
     public void execute(final D violationData) {
         final String command = getMessage(violationData);
-        SchedulerHelper.runSyncTask(plugin, (arg) -> {
-        	try {
+        final Runnable runCommand = () -> {
+            try {
                 Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), command);
                 if (logDebug) {
                     debug(violationData, command);
@@ -74,7 +75,20 @@ public class CommandAction<D extends ParameterHolder, L extends AbstractActionLi
                 StaticLog.logOnce(Level.WARNING, "Failed to execute the command '" + command + "': " + e.getMessage()
                 + ", please check if everything is setup correct.", StringUtil.throwableToString(e));
             }
-        });
+        };
+        if (plugin == null) {
+            runCommand.run();
+            return;
+        }
+        if (SchedulerHelper.isFoliaServer() && violationData instanceof ViolationData) {
+            final Player player = ((ViolationData) violationData).player;
+            if (player != null) {
+                SchedulerHelper.runSyncTaskForEntity(player, plugin, (arg) -> runCommand.run(),
+                        () -> SchedulerHelper.runSyncTask(plugin, (arg) -> runCommand.run()));
+                return;
+            }
+        }
+        SchedulerHelper.runSyncTask(plugin, (arg) -> runCommand.run());
     }
 
     private void debug(final D violationData, String command) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
@@ -28,6 +28,8 @@ import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.compat.bukkit.BridgePotionEffect;
 import fr.neatmonster.nocheatplus.permissions.Permissions;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.entity.PotionUtil;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
@@ -62,6 +64,11 @@ public class FastBreak extends Check {
                                          // Counting break...break.
                                          : (data.fastBreakBreakTime > now) ? 0 : now - data.fastBreakBreakTime;
 
+        /*
+         * FastBreak compatibility: keep the grace threshold configurable.
+         * The safer modern default belongs in config, while this check only
+         * compares measured block/tool timing against that configured budget.
+         */
         // Check if the time spent is lower than expected.
         if (isInstaBreak.decideOptimistically()) {
             // Ignore these for now.
@@ -80,13 +87,26 @@ public class FastBreak extends Check {
                 // Add as penalty
                 data.fastBreakPenalties.add(now, (float) missingTime);
                 // Only raise a violation, if the total penalty score exceeds the contention duration (for lag, delay).
-                if (data.fastBreakPenalties.score(cc.fastBreakBucketFactor) > cc.fastBreakGrace) {
+                final float penaltyScore = data.fastBreakPenalties.score(cc.fastBreakBucketFactor);
+                if (penaltyScore > cc.fastBreakGrace) {
                     // TODO: maybe add one absolute penalty time for big amounts to stop breaking until then
                     final double violation = (double) missingTime / 1000.0;
                     data.fastBreakVL += violation;
+                    final ItemStack stack = Bridge1_9.getItemInMainHand(player);
+                    final Material toolType = stack == null ? Material.AIR : stack.getType();
+                    final boolean isValidTool = BlockProperties.isValidTool(blockType, stack);
+                    final double haste = PotionUtil.getPotionEffectAmplifier(player, BridgePotionEffect.HASTE);
+                    // Diagnostic info: tag the timing branch so false FastBreak reports show the block/tool context.
+                    final String tags = getFastBreakTags(isInstaBreak, cc, isValidTool, haste, elapsedTime, missingTime);
                     final ViolationData vd = new ViolationData(this, player, data.fastBreakVL, violation, cc.fastBreakActions);
                     if (vd.needsParameters()) {
                         vd.setParameter(ParameterName.BLOCK_TYPE, blockType.toString());
+                        vd.setParameter(ParameterName.TAGS, tags);
+                    }
+                    if (CheckUtils.shouldLogDebugToConsole()) {
+                        logFastBreakDetail(player, blockType, toolType, isInstaBreak, isValidTool, haste,
+                                elapsedTime, expectedBreakingTime, missingTime, serverLagFactor,
+                                penaltyScore, data.fastBreakVL, violation, cc, tags);
                     }
                     cancel = executeActions(vd).willCancel();
                 }
@@ -131,5 +151,70 @@ public class FastBreak extends Check {
             //              player.sendMessage("mc speed: " + x);
             //          }
         }
+    }
+
+    private String getFastBreakTags(final AlmostBoolean isInstaBreak, final BlockBreakConfig cc,
+                                    final boolean isValidTool, final double haste,
+                                    final long elapsedTime, final long missingTime) {
+        // Diagnostic info: these tags describe why the umbrella FastBreak check added VL.
+        final StringBuilder builder = new StringBuilder(120);
+        builder.append("subcheck_fastbreak_timing")
+                .append("+branch_expected_duration")
+                .append(cc.fastBreakStrict ? "+strict_interact_break" : "+break_break")
+                .append("+insta_").append(isInstaBreak.name().toLowerCase())
+                .append(isValidTool ? "+valid_tool" : "+invalid_tool");
+        if (Double.isInfinite(haste)) {
+            builder.append("+no_haste");
+        }
+        else {
+            builder.append("+haste_").append((int) haste + 1);
+        }
+        if (elapsedTime == 0L) {
+            builder.append("+zero_elapsed");
+        }
+        if (missingTime >= 1000L) {
+            builder.append("+large_missing_time");
+        }
+        return builder.toString();
+    }
+
+    private void logFastBreakDetail(final Player player, final Material blockType, final Material toolType,
+                                    final AlmostBoolean isInstaBreak, final boolean isValidTool,
+                                    final double haste, final long elapsedTime,
+                                    final long expectedBreakingTime, final long missingTime,
+                                    final float serverLagFactor, final float penaltyScore,
+                                    final double totalVL, final double addedVL,
+                                    final BlockBreakConfig cc, final String tags) {
+        try {
+            // Diagnostic info: console-only detail for tuning FastBreak grace without changing check behavior.
+            player.getServer().getLogger().info(new StringBuilder(380)
+                    .append("[NCP][FastBreak][detail] player=").append(player.getName())
+                    .append(" uuid=").append(player.getUniqueId())
+                    .append(" subcheck=FASTBREAK_TIMING")
+                    .append(" summary=block_timing{missingMs=").append(missingTime)
+                    .append(",graceMs=").append(StringUtil.fdec3.format(cc.fastBreakGrace))
+                    .append(",tool=").append(isValidTool ? "valid" : "invalid")
+                    .append(",insta=").append(isInstaBreak.name().toLowerCase())
+                    .append('}')
+                    .append(" block=").append(blockType)
+                    .append(" tool=").append(toolType)
+                    .append(" validTool=").append(isValidTool)
+                    .append(" insta=").append(isInstaBreak.name())
+                    .append(" strict=").append(cc.fastBreakStrict)
+                    .append(" elapsedMs=").append(elapsedTime)
+                    .append(" expectedMs=").append(expectedBreakingTime)
+                    .append(" missingMs=").append(missingTime)
+                    .append(" lagFactor=").append(StringUtil.fdec3.format(serverLagFactor))
+                    .append(" penaltyScore=").append(StringUtil.fdec3.format(penaltyScore))
+                    .append(" graceMs=").append(StringUtil.fdec3.format(cc.fastBreakGrace))
+                    .append(" delayMs=").append(cc.fastBreakDelay)
+                    .append(" modSurvival=").append(cc.fastBreakModSurvival)
+                    .append(" haste=").append(Double.isInfinite(haste) ? "none" : Integer.toString((int) haste + 1))
+                    .append(" addVL=").append(StringUtil.fdec3.format(addedVL))
+                    .append(" totalVL=").append(StringUtil.fdec3.format(totalVL))
+                    .append(" tags=").append(tags)
+                    .toString());
+        }
+        catch (Throwable ignored) {}
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatListener.java
@@ -31,6 +31,7 @@ import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.CheckListener;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
+import fr.neatmonster.nocheatplus.checks.net.NetData;
 import fr.neatmonster.nocheatplus.command.CommandUtil;
 import fr.neatmonster.nocheatplus.compat.BridgeMisc;
 import fr.neatmonster.nocheatplus.compat.SchedulerHelper;
@@ -162,6 +163,16 @@ public class ChatListener extends CheckListener implements INotifyReload, JoinLe
         }
     }
 
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerTeleportCommandMonitor(final PlayerCommandPreprocessEvent event) {
+        final String command = getTeleportLikeCommand(event.getMessage());
+        if (command != null) {
+            final Player player = event.getPlayer();
+            DataManager.getPlayerData(player).getGenericInstance(NetData.class)
+                    .recordTeleportCommand(command, player.getLocation(), System.currentTimeMillis());
+        }
+    }
+
     /** We listen to PlayerCommandPreprocess events because commands can be used for spamming too. */
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerCommandPreprocess(final PlayerCommandPreprocessEvent event) {
@@ -224,6 +235,45 @@ public class ChatListener extends CheckListener implements INotifyReload, JoinLe
                 }
             }
         }
+    }
+
+    private String getTeleportLikeCommand(final String message) {
+        if (message == null) {
+            return null;
+        }
+        final String lcMessage = StringUtil.leftTrim(message).toLowerCase();
+        if (lcMessage.length() < 2 || lcMessage.charAt(0) != '/') {
+            return null;
+        }
+        final String[] split = lcMessage.split(" ", 2);
+        String command = split[0].substring(1);
+        final int namespaceIndex = command.indexOf(':');
+        if (namespaceIndex >= 0 && namespaceIndex + 1 < command.length()) {
+            command = command.substring(namespaceIndex + 1);
+        }
+        return isTeleportLikeCommand(command) ? command : null;
+    }
+
+    private boolean isTeleportLikeCommand(final String command) {
+        return command.equals("rtp")
+            || command.equals("randomtp")
+            || command.equals("randomteleport")
+            || command.equals("wild")
+            || command.equals("wilderness")
+            || command.equals("spawn")
+            || command.equals("hub")
+            || command.equals("lobby")
+            || command.equals("home")
+            || command.equals("homes")
+            || command.equals("warp")
+            || command.equals("warps")
+            || command.equals("back")
+            || command.equals("tpa")
+            || command.equals("tpaccept")
+            || command.equals("tpahere")
+            || command.equals("tp")
+            || command.equals("teleport")
+            || command.equals("tphere");
     }
 
     private boolean checkUntrackedLocation(final Player player, final String message, 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
@@ -233,6 +233,8 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     public double noFallMaxY = 0;
     /** Indicate that NoFall is not to use next damage event for checking on-ground properties. */ 
     public boolean noFallSkipAirCheck = false;
+    /** Elytra NoFall model: last time glide movement reset fall-distance accounting. */
+    public long noFallElytraResetTime = 0L;
     /** Last coordinate from when the player was affected wind charge explosion */
     public Location noFallCurrentLocOnWindChargeHit = null;
 
@@ -249,6 +251,30 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     public int sfHoverTicks = -1;
     /** First count these down before incrementing sfHoverTicks. Set on join, if configured so. */
     public int sfHoverLoginTicks = 0;
+    /** Hover model: airborne ticks included in the accumulated descent budget. */
+    public int hoverAirTicks = 0;
+    /** Hover model: total downward movement expected from gravity/glide prediction, plus unexplained ascent debt. */
+    public double hoverExpectedDrop = 0.0;
+    /** Hover model: total downward movement actually sent by the client. */
+    public double hoverActualDrop = 0.0;
+    /** Hover model: last predicted vertical velocity used for budget continuity. */
+    public double hoverLastYVelocity = 0.0;
+    /** Elytra model: consecutive no-firework upward glide packets outside the energy envelope. */
+    public int elytraNoFireworkAscentTicks = 0;
+    /** Elytra model: accumulated no-firework ascent above speed/dive-derived lift. */
+    public double elytraNoFireworkAscentDebt = 0.0;
+    /** Elytra model diagnostics: allowed upward movement from decayed/dive/speed lift for the last no-firework glide packet. */
+    public double elytraNoFireworkAscentBudget = 0.0;
+    /** Elytra model diagnostics: upward movement above the last no-firework ascent budget. */
+    public double elytraNoFireworkAscentExcess = 0.0;
+    /** Elytra model diagnostics: horizontal speed needed if speed lift alone were explaining the observed ascent. */
+    public double elytraNoFireworkNeededH = Double.NaN;
+    /** Elytra model: session energy bank created by actual no-firework descent. */
+    public double elytraNoFireworkDescentCredit = 0.0;
+    /** Elytra model diagnostics: descent credit used by the last accepted no-firework ascent packet. */
+    public double elytraNoFireworkDescentCreditUsed = 0.0;
+    /** Elytra model: first location of the current no-firework glide session, used as the illegal-ascent correction anchor. */
+    public Location elytraNoFireworkStart = null;
     /** Fake in air flag: set with any violation, reset once on ground. */
     public boolean sfVLInAir = false;
     /** Workarounds (AirWorkarounds,LiquidWorkarounds). */
@@ -349,6 +375,7 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
         removeAllPlayerSpeedModifiers();
         clearWindChargeImpulse();
         sfHoverTicks = sfHoverLoginTicks = -1;
+        resetHoverAirBudget();
         liftOffEnvelope = defaultLiftOffEnvelope;
         vehicleConsistency = MoveConsistency.INCONSISTENT;
         verticalBounce = null;
@@ -378,6 +405,7 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
         // Keep jump amplifier
         // keep jump phase.
         sfHoverTicks = -1; // 0 ?
+        resetHoverAirBudget();
         liftOffEnvelope = defaultLiftOffEnvelope;
         removeAllPlayerSpeedModifiers();
         vehicleConsistency = MoveConsistency.INCONSISTENT; // Not entirely sure here.
@@ -409,7 +437,24 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
         verticalBounce = null;
         // Remember where we send the player to.
         setTeleported(loc);
-        // TODO: sfHoverTicks ?
+        sfHoverTicks = -1;
+        resetHoverAirBudget();
+    }
+
+
+    public void resetHoverAirBudget() {
+        hoverAirTicks = 0;
+        hoverExpectedDrop = 0.0;
+        hoverActualDrop = 0.0;
+        hoverLastYVelocity = 0.0;
+        elytraNoFireworkAscentTicks = 0;
+        elytraNoFireworkAscentDebt = 0.0;
+        elytraNoFireworkAscentBudget = 0.0;
+        elytraNoFireworkAscentExcess = 0.0;
+        elytraNoFireworkNeededH = Double.NaN;
+        elytraNoFireworkDescentCredit = 0.0;
+        elytraNoFireworkDescentCreditUsed = 0.0;
+        elytraNoFireworkStart = null;
     }
 
 
@@ -547,6 +592,25 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
         morePacketsFreq.clear(now);
         morePacketsBurstFreq.clear(now);
         // TODO: Also reset other data ?
+    }
+
+
+    public void onExternalTeleportResync(final Location loc) {
+        // Teleport/Folia support: NET_MOVING accepted a stale pre-teleport packet, so old move history must not
+        // remain available as a future setback target.
+        playerMoves.invalidate();
+        clearPlayerMorePacketsData();
+        sfJumpPhase = 0;
+        sfHoverTicks = -1;
+        resetHoverAirBudget();
+        verticalBounce = null;
+        timeSinceSetBack = 0;
+        if (loc != null && loc.getWorld() != null) {
+            // Folia/teleport safety: packet models can carry coordinate-only targets, but set backs need a real world.
+            setSetBack(loc);
+        }
+        resetTeleported();
+        joinOrRespawn = false;
     }
 
 
@@ -835,14 +899,14 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
      * Set on {@link org.bukkit.event.player.PlayerRiptideEvent} to "MAYBE", as we don't yet know whether the riptide push is applied with or without the 1.2 vertical move from ground.
      */
     public void setTridentReleaseEvent(AlmostBoolean isReleased) {
-        tridentRelease = isReleased;
+        tridentRelease = isReleased == null ? AlmostBoolean.NO : isReleased;
     }
 
     /**
      * Set when pass to PlayerMoveData, also reset state
      */
     public AlmostBoolean consumeTridentReleaseEvent() {
-        final AlmostBoolean result = tridentRelease;
+        final AlmostBoolean result = tridentRelease == null ? AlmostBoolean.NO : tridentRelease;
         tridentRelease = AlmostBoolean.NO;
         return result;
     }
@@ -1021,6 +1085,10 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     public List<PairEntry> useHorizontalVelocity(final double x, final double z) {
         final List<PairEntry> available = horVel.use(x, z, 0.001);
         return available;
+    }
+
+    public List<PairEntry> useHorizontalVelocityCovering(final double x, final double z, final int maxActCount) {
+        return horVel.useCovering(x, z, 1, maxActCount, 0.001);
     }
 
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/velocity/PairAxisVelocity.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/velocity/PairAxisVelocity.java
@@ -164,6 +164,88 @@ public class PairAxisVelocity {
     }
 
     /**
+     * Use the next velocity entry that can cover the demanded x/z displacement.
+     * This is meant for knockback-style compensation, where the player may only
+     * consume part of a queued velocity vector during one move.
+     */
+    public List<PairEntry> useCovering(final double x, final double z, final int minActCount,
+                                       final int maxActCount, final double tolerance) {
+        final List<PairEntry> available = peekCovering(x, z, minActCount, maxActCount, tolerance);
+        if (available.isEmpty()) {
+            return available;
+        }
+        return use(available.get(0).tick);
+    }
+
+    public List<PairEntry> peekCovering(final double x, final double z, final int minActCount,
+                                        final int maxActCount, final double tolerance) {
+        final List<PairEntry> result = new LinkedList<>();
+        double totalAmountX = 0;
+        double totalAmountZ = 0;
+        int lastTick = 0;
+        boolean hasVel = false;
+        final Iterator<PairEntry> it = queued.iterator();
+        while (it.hasNext()) {
+            final PairEntry entry = it.next();
+            if (entry.actCount < minActCount || entry.actCount > maxActCount) {
+                continue;
+            }
+            if ((entry.flags & VelocityFlags.ADDITIVE) != 0 && lastTick == entry.tick) {
+                totalAmountX += entry.x;
+                totalAmountZ += entry.z;
+                result.add(entry);
+                hasVel = true;
+            }
+            else {
+                if (hasVel && coversVector(totalAmountX, totalAmountZ, x, z, tolerance)) {
+                    return result;
+                }
+                result.clear();
+                totalAmountX = entry.x;
+                totalAmountZ = entry.z;
+                lastTick = entry.tick;
+                result.add(entry);
+                hasVel = true;
+            }
+        }
+        if (hasVel && coversVector(totalAmountX, totalAmountZ, x, z, tolerance)) {
+            return result;
+        }
+        result.clear();
+        return result;
+    }
+
+    private boolean covers(final double velocity, final double amount, final double tolerance) {
+        return Math.abs(amount) <= tolerance
+                || Math.signum(velocity) == Math.signum(amount)
+                && Math.abs(amount) <= Math.abs(velocity) + tolerance;
+    }
+
+    private boolean coversVector(final double velocityX, final double velocityZ,
+                                 final double amountX, final double amountZ,
+                                 final double tolerance) {
+        final double amountSq = amountX * amountX + amountZ * amountZ;
+        if (amountSq <= tolerance * tolerance) {
+            return true;
+        }
+        final double velocitySq = velocityX * velocityX + velocityZ * velocityZ;
+        if (velocitySq <= tolerance * tolerance) {
+            return false;
+        }
+        final double dot = velocityX * amountX + velocityZ * amountZ;
+        if (dot < -tolerance) {
+            return false;
+        }
+        final double amount = Math.sqrt(amountSq);
+        final double velocity = Math.sqrt(velocitySq);
+        if (amount > velocity + tolerance) {
+            return false;
+        }
+        final double perpendicular = Math.abs(velocityX * amountZ - velocityZ * amountX) / velocity;
+        return perpendicular <= Math.max(tolerance, 0.02);
+    }
+
+    /**
      * Without checking for invalidation, test if there is a matching entry with
      * same or less the activation count.
      * 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveDiagnostics.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveDiagnostics.java
@@ -1,0 +1,81 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.checks.net;
+
+import org.bukkit.entity.Player;
+
+import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
+import fr.neatmonster.nocheatplus.utilities.TickTask;
+
+/**
+ * Console-only formatting for KeepAliveFrequency diagnostics.
+ */
+final class KeepAliveDiagnostics {
+
+    private KeepAliveDiagnostics() {}
+
+    static String formatDetail(final Player player, final long packetTime, final long now, final long joinTime,
+                               final NetData data, final NetConfig cc, final IPlayerData pData,
+                               final float first, final float fullScore, final double vl,
+                               final boolean cancel, final String model, final float firstLimit) {
+        final long bucketDuration = data.keepAliveFreq.bucketDuration();
+        final int buckets = data.keepAliveFreq.numberOfBuckets();
+        return new StringBuilder(900)
+                .append("[NCP][KeepAliveFrequency][detail] player=").append(player.getName())
+                .append(" uuid=").append(player.getUniqueId())
+                .append(" client=").append(pData.getClientVersion())
+                .append(" summary=keepalive_bucket{first=").append(StringUtil.fdec3.format(first))
+                .append(",full=").append(StringUtil.fdec3.format(fullScore))
+                .append(",expected=").append(data.keepAliveFreq.numberOfBuckets())
+                .append(",cancel=").append(cancel)
+                .append('}')
+                .append(" packetTime=").append(packetTime)
+                .append(" now=").append(now)
+                .append(" joinAge=").append(joinTime <= 0L ? -1L : now - joinTime)
+                .append(" startupDelay=").append(cc.keepAliveFrequencyStartupDelay)
+                .append(" vl=").append(StringUtil.fdec3.format(vl))
+                .append(" cancel=").append(cancel)
+                .append(" model=").append(model)
+                .append(" firstLimit=").append(StringUtil.fdec3.format(firstLimit))
+                .append(" firstBucket=").append(StringUtil.fdec3.format(first))
+                .append(" fullScore=").append(StringUtil.fdec3.format(fullScore))
+                .append(" expectedFull=").append(buckets)
+                .append(" bucketDuration=").append(bucketDuration)
+                .append(" bucketAge=").append(now - data.keepAliveFreq.lastAccess())
+                .append(" lastUpdateAge=").append(now - data.keepAliveFreq.lastUpdate())
+                .append(" lag1s=").append(StringUtil.fdec3.format(TickTask.getLag(bucketDuration, true)))
+                .append(" lagWindow=").append(StringUtil.fdec3.format(TickTask.getLag(bucketDuration * buckets, true)))
+                .append(" buckets=").append(formatBuckets(data, Math.min(6, buckets)))
+                .append(" state=").append(data.describeKeepAliveState(now))
+                .toString();
+    }
+
+    private static String formatBuckets(final NetData data, final int limit) {
+        final StringBuilder builder = new StringBuilder(80);
+        builder.append('[');
+        for (int i = 0; i < limit; i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append(StringUtil.fdec3.format(data.keepAliveFreq.bucketScore(i)));
+        }
+        if (limit < data.keepAliveFreq.numberOfBuckets()) {
+            builder.append(",...");
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveFrequency.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveFrequency.java
@@ -19,6 +19,7 @@ import org.bukkit.entity.Player;
 import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
 
 public class KeepAliveFrequency extends Check {
 
@@ -35,21 +36,95 @@ public class KeepAliveFrequency extends Check {
      * @return If to cancel.
      */
     public boolean check(final Player player, final long time, final NetData data, final NetConfig cc, final IPlayerData pData) {
-        data.keepAliveFreq.add(time, 1f);
-        final float first = data.keepAliveFreq.bucketScore(0);
         final long now = System.currentTimeMillis();
-        
-        if (now > pData.getLastJoinTime() && pData.getLastJoinTime() + cc.keepAliveFrequencyStartupDelay * 1000 < now) {
+        final long joinTime = pData.getLastJoinTime();
+        if (joinTime > 0L && now < joinTime + cc.keepAliveFrequencyStartupDelay) {
             return false;
         }
+        if (data.keepAliveExpectedResponse && !data.keepAliveDuplicateId) {
+            return false;
+        }
+        data.keepAliveFreq.add(time, 1f);
+        final float first = data.keepAliveFreq.bucketScore(0);
         
         if (first > 1f) {
             // Trigger a violation.
-            final double vl = Math.max(first - 1f, data.keepAliveFreq.score(1f) - data.keepAliveFreq.numberOfBuckets());
-            if (executeActions(player, vl, 1.0, cc.keepAliveFrequencyActions).willCancel()) {
-                return true;
+            final float fullScore = data.keepAliveFreq.score(1f);
+            if (isModeledBoundaryBurst(data, fullScore, first)) {
+                return false;
             }
+            final double vl = Math.max(first - getFirstBucketViolationLimit(data), fullScore - data.keepAliveFreq.numberOfBuckets());
+            final boolean cancel = executeActions(player, vl, 1.0, cc.keepAliveFrequencyActions).willCancel();
+            if (CheckUtils.shouldLogDebugToConsole()) {
+                // Diagnostic info: bucket details separate duplicate packets from normal boundary timing.
+                logConsoleDetails(player, time, now, joinTime, data, cc, pData, first, fullScore, vl,
+                        cancel, describeKeepAliveModel(data, fullScore, first), getFirstBucketViolationLimit(data));
+            }
+            return cancel;
         }
         return false;
+    }
+
+    private boolean isModeledBoundaryBurst(final NetData data, final float fullScore, final float first) {
+        // KeepAlive model: if outgoing tracking is unavailable, only treat small monotonic id bursts as timing leftovers.
+        if (data.keepAliveDuplicateId || fullScore > data.keepAliveFreq.numberOfBuckets() + 2f) {
+            return false;
+        }
+        // Folia/netty can timestamp two adjacent valid replies in the same millisecond; do not cancel a single pair.
+        return first <= 2f || isUntrackedMonotonicBurst(data, fullScore, first);
+    }
+
+    private boolean isUntrackedMonotonicBurst(final NetData data, final float fullScore, final float first) {
+        if (data.keepAliveOutgoingSeen || fullScore > data.keepAliveFreq.numberOfBuckets()) {
+            return false;
+        }
+        if (!data.keepAlivePacketIdAvailable || !data.keepAlivePreviousPacketIdAvailable) {
+            return false;
+        }
+        if (data.keepAlivePacketId <= data.keepAlivePreviousPacketId) {
+            return false;
+        }
+        return first <= getFallbackFirstBucketLimit(data);
+    }
+
+    private float getFirstBucketViolationLimit(final NetData data) {
+        if (data.keepAliveDuplicateId) {
+            return 1f;
+        }
+        if (!data.keepAliveOutgoingSeen
+                && data.keepAlivePacketIdAvailable
+                && data.keepAlivePreviousPacketIdAvailable
+                && data.keepAlivePacketId > data.keepAlivePreviousPacketId) {
+            return getFallbackFirstBucketLimit(data);
+        }
+        return 2f;
+    }
+
+    private float getFallbackFirstBucketLimit(final NetData data) {
+        return Math.max(3f, Math.min(6f, data.keepAliveFreq.numberOfBuckets() / 4f));
+    }
+
+    private String describeKeepAliveModel(final NetData data, final float fullScore, final float first) {
+        if (data.keepAliveDuplicateId) {
+            return "duplicate-id";
+        }
+        if (data.keepAliveOutgoingSeen) {
+            return "unmatched-outgoing";
+        }
+        if (isUntrackedMonotonicBurst(data, fullScore, first)) {
+            return "untracked-monotonic-burst";
+        }
+        return "bucket-frequency";
+    }
+
+    private void logConsoleDetails(final Player player, final long packetTime, final long now, final long joinTime,
+                                   final NetData data, final NetConfig cc, final IPlayerData pData,
+                                   final float first, final float fullScore, final double vl,
+                                   final boolean cancel, final String model, final float firstLimit) {
+        try {
+            player.getServer().getLogger().info(KeepAliveDiagnostics.formatDetail(player, packetTime, now, joinTime,
+                    data, cc, pData, first, fullScore, vl, cancel, model, firstLimit));
+        }
+        catch (Throwable ignored) {}
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/Moving.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/Moving.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.util.Vector;
 
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.actions.ParameterName;
@@ -27,7 +28,11 @@ import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.checks.ViolationData;
 import fr.neatmonster.nocheatplus.checks.moving.MovingData;
+import fr.neatmonster.nocheatplus.checks.moving.model.LocationData;
+import fr.neatmonster.nocheatplus.checks.moving.model.PlayerKeyboardInput;
+import fr.neatmonster.nocheatplus.checks.moving.model.PlayerMoveData;
 import fr.neatmonster.nocheatplus.checks.net.model.DataPacketFlying;
+import fr.neatmonster.nocheatplus.checks.net.model.DataPacketInput;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.CheckUtils;
@@ -41,10 +46,6 @@ import fr.neatmonster.nocheatplus.utilities.math.TrigUtil;
  */
 public class Moving extends Check {
 
-    /** For temporary use: LocUtil.clone before passing deeply, call setWorld(null) after use. */
-    final Location useLoc = new Location(null, 0, 0, 0);
-    final List<String> tags = new ArrayList<String>();
-    
     public Moving() {
         super(CheckType.NET_MOVING);
     }
@@ -67,27 +68,114 @@ public class Moving extends Check {
         boolean cancel = false;
         final long now = System.currentTimeMillis();
         final boolean debug = pData.isDebugActive(CheckType.NET_MOVING);
-        tags.clear();
+        final List<String> tags = new ArrayList<String>();
         if (now > pData.getLastJoinTime() && pData.getLastJoinTime() + 10000 > now) {
             tags.add("login_grace");
         	return false;
         }
+        if (player.isDead()) {
+            tags.add("dead_grace");
+            data.movingVL *= 0.5;
+            return false;
+        }
         if (packetData != null && packetData.hasPos) {
             final MovingData mData = pData.getGenericInstance(MovingData.class);
             /** Actual Location on the server */
-            final Location knownLocation = player.getLocation(useLoc);
+            final Location useLoc = new Location(null, 0, 0, 0);
+            final Location rawKnownLocation = player.getLocation(useLoc);
+            if (rawKnownLocation == null || rawKnownLocation.getWorld() == null) {
+                // Folia compatibility: a disconnecting player can leave the temporary Location without a world.
+                tags.add("known_world_null_grace");
+                useLoc.setWorld(null);
+                return false;
+            }
+            // Folia/packet safety: keep packet-thread teleport models away from mutable temporary Location state.
+            final Location knownLocation = LocUtil.clone(rawKnownLocation);
+            useLoc.setWorld(null);
+            data.recordMovingKnownLocation(knownLocation, now);
             /** Claimed Location sent by the client */
             final Location packetLocation = new Location(null, packetData.getX(), packetData.getY(), packetData.getZ());
             //final double distanceSq = TrigUtil.distanceSquared(knownLocation, packetLocation);
             final double yDistance = Math.abs(knownLocation.getY() - packetLocation.getY());
             final double hDistance = TrigUtil.xzDistance(knownLocation, packetLocation);
             final double distance = TrigUtil.distance(knownLocation, packetLocation);
+            final boolean extremeMove = yDistance > 100.0 || distance > 100.0;
+
+            final boolean teleportGrace = data.isWithinMovingTeleportGrace(now);
+            final boolean outgoingPositionGrace = data.isWithinOutgoingPositionGrace(now, knownLocation);
+            final boolean serverPositionJumpModel = data.isWithinServerPositionJumpStalePacketModel(now,
+                    knownLocation, packetLocation, packetData);
+            final boolean teleportCommandModel = data.isWithinTeleportCommandStalePacketModel(now,
+                    knownLocation, packetLocation, packetData);
+            final boolean teleportResyncStalePacketDropModel = (serverPositionJumpModel || teleportCommandModel)
+                    && data.isWithinTeleportResyncStalePacketDropModel(now, knownLocation, packetLocation, packetData);
+            final boolean expectedOutgoingPositionGrace = extremeMove && data.consumeExpectedOutgoingPosition(packetData);
+            final boolean serverPositionJumpRecoveryGrace = extremeMove
+                    && !serverPositionJumpModel
+                    && !teleportCommandModel
+                    && isServerPositionJumpRecoveryContext(mData)
+                    && data.consumeServerPositionJumpRecoveryGrace(now, knownLocation);
+            // NetMoving compatibility: match extreme packets against teleport/server-position history before flagging.
+            if (extremeMove && (teleportGrace || outgoingPositionGrace || expectedOutgoingPositionGrace
+                    || serverPositionJumpModel || serverPositionJumpRecoveryGrace || teleportCommandModel)) {
+                if (teleportGrace) {
+                    tags.add("teleport_grace");
+                }
+                if (outgoingPositionGrace) {
+                    tags.add("outgoing_position_grace");
+                }
+                if (expectedOutgoingPositionGrace) {
+                    tags.add("expected_outgoing_position_grace");
+                }
+                if (serverPositionJumpModel) {
+                    tags.add("server_position_jump_stale_packet_model");
+                }
+                if (serverPositionJumpRecoveryGrace) {
+                    tags.add("server_position_jump_recovery_grace");
+                }
+                if (teleportCommandModel) {
+                    tags.add("teleport_command_stale_packet_model");
+                }
+                if (serverPositionJumpModel || teleportCommandModel) {
+                    tags.add("teleport_resync_history_reset");
+                }
+                if (teleportResyncStalePacketDropModel) {
+                    tags.add("teleport_resync_stale_packet_drop");
+                }
+                if (CheckUtils.shouldLogDebugToConsole()
+                        && !(serverPositionJumpModel || teleportCommandModel)) {
+                    final String reason = serverPositionJumpModel || teleportCommandModel ? "model" : "grace";
+                    logConsoleDetails(reason, tags, player, packetData, knownLocation, packetLocation, hDistance, yDistance,
+                            distance, data, mData, pData, now);
+                }
+                if (serverPositionJumpModel || teleportCommandModel) {
+                    final String reason = serverPositionJumpModel ? "server_position_jump_stale_packet_model"
+                            : "teleport_command_stale_packet_model";
+                    // Teleport model: accepted stale packets are deleted from packet history, not kept as movement data.
+                    if (teleportResyncStalePacketDropModel) {
+                        data.acceptMovingTeleportStalePacketContinuation(player, knownLocation, packetLocation,
+                                packetData, now, reason);
+                    }
+                    else {
+                        data.acceptMovingTeleportResync(player, plugin, mData, knownLocation, packetLocation,
+                                packetData, now, reason);
+                    }
+                }
+                data.movingVL *= 0.98;
+                return false;
+            }
 
             // 100 it's the minimum [Math.max(100, config distance)]distance for the 'moved too quickly' check to fire
             // See PlayerConnection.java
-            if (yDistance > 100.0 || distance > 100.0/*distanceSq > 100.0 || hDistance > 100.0*/) {
+            if (extremeMove/*distanceSq > 100.0 || hDistance > 100.0*/) {
                 data.movingVL++ ;
                 tags.add("invalid_pos");
+                // Diagnostic info: separate net extreme-move flags from teleport/grace branches.
+                tags.add(0, "subcheck_netmoving_extreme_move");
+                if (CheckUtils.shouldLogDebugToConsole()) {
+                    logConsoleDetails("violation", tags, player, packetData, knownLocation, packetLocation, hDistance, yDistance,
+                            distance, data, mData, pData, now);
+                }
                 final ViolationData vd = new ViolationData(this, player, data.movingVL, 1.0, cc.movingActions);
                 if (vd.needsParameters()) vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));
                 cancel = executeActions(vd).willCancel();
@@ -98,20 +186,341 @@ public class Moving extends Check {
         }
 
         if (debug) {
-            final Location packetLocation = new Location(null, packetData.getX(), packetData.getY(), packetData.getZ());
             final StringBuilder builder = new StringBuilder(500);
-            if (packetData.hasPos) {
+            if (packetData != null && packetData.hasPos) {
+                final Location packetLocation = new Location(null, packetData.getX(), packetData.getY(), packetData.getZ());
+                final Location serverLocation = player.getLocation();
                 builder.append(CheckUtils.getLogMessagePrefix(player, type));
                 builder.append("\nPacket location: " + LocUtil.simpleFormat(packetLocation));
-                builder.append("\nServer location: " + LocUtil.simpleFormat(player.getLocation(useLoc)));
-                builder.append("\nDeltas: h= " + TrigUtil.distance(player.getLocation(useLoc), packetLocation) + ", y= " + Math.abs(player.getLocation(useLoc).getY() - packetLocation.getY()));
+                builder.append("\nServer location: " + LocUtil.simpleFormat(serverLocation));
+                builder.append("\nDeltas: h= " + TrigUtil.distance(serverLocation, packetLocation) + ", y= " + Math.abs(serverLocation.getY() - packetLocation.getY()));
             }
             else {
             	builder.append("Empty packet (no position)");
             }
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().debug(Streams.TRACE_FILE, builder.toString());
         }
-        useLoc.setWorld(null);
         return cancel;
+    }
+
+    private boolean isServerPositionJumpRecoveryContext(final MovingData data) {
+        // False-positive tuning: death/respawn and portal/server jumps can leave move history invalid for one packet.
+        final PlayerMoveData currentMove = data.playerMoves.getCurrentMove();
+        final PlayerMoveData lastMove = data.playerMoves.getFirstPastMove();
+        return data.joinOrRespawn
+                || !data.hasSetBack()
+                || !currentMove.toIsValid
+                || !lastMove.toIsValid;
+    }
+
+    private void logConsoleDetails(final String reason, final List<String> tags,
+                                   final Player player, final DataPacketFlying packetData,
+                                   final Location knownLocation, final Location packetLocation,
+                                   final double hDistance, final double yDistance, final double distance,
+                                   final NetData data, final MovingData mData, final IPlayerData pData,
+                                   final long now) {
+        try {
+            final String joinedTags = StringUtil.join(tags, "+");
+            player.getServer().getLogger().info(new StringBuilder(700)
+                    .append("[NCP][NetMoving][detail] player=").append(player.getName())
+                    .append(" reason=").append(reason)
+                    .append(" subcheck=").append("violation".equals(reason) ? "NETMOVING_EXTREME_MOVE"
+                            : "model".equals(reason) ? "NETMOVING_TELEPORT_RESYNC_MODEL" : "NETMOVING_GRACE")
+                    .append(" summary=net_moving{reason=").append(reason)
+                    .append(",h=").append(StringUtil.fdec3.format(hDistance))
+                    .append(",y=").append(StringUtil.fdec3.format(yDistance))
+                    .append(",total=").append(StringUtil.fdec3.format(distance))
+                    .append(",tags=").append(joinedTags.isEmpty() ? "none" : joinedTags)
+                    .append('}')
+                    .append(" uuid=").append(player.getUniqueId())
+                    .append(" client=").append(pData.getClientVersion())
+                    .append(" now=").append(now)
+                    .append(" joinAge=").append(now - pData.getLastJoinTime())
+                    .append(" keepAliveAge=").append(data.lastKeepAliveTime <= 0L ? -1L : now - data.lastKeepAliveTime)
+                    .append(" movingVL=").append(StringUtil.fdec3.format(data.movingVL))
+                    .append(" teleportGraceAge=").append(data.getMovingTeleportGraceAge(now))
+                    .append(" outgoingGraceAge=").append(data.getOutgoingPositionGraceAge(now))
+                    .append(" known=").append(LocUtil.simpleFormat(knownLocation))
+                    .append(" packet=").append(LocUtil.simpleFormat(packetLocation))
+                    .append(" hDist=").append(StringUtil.fdec3.format(hDistance))
+                    .append(" yDist=").append(StringUtil.fdec3.format(yDistance))
+                    .append(" distance=").append(StringUtil.fdec3.format(distance))
+                    .append(" vector=known-packet(").append(formatVector(knownLocation.getX() - packetLocation.getX(),
+                            knownLocation.getY() - packetLocation.getY(), knownLocation.getZ() - packetLocation.getZ())).append(')')
+                    .append(" packetMeta=").append(formatPacket(packetData, now))
+                    .append(" tags=").append(joinedTags)
+                    .toString());
+            player.getServer().getLogger().info(new StringBuilder(900)
+                    .append("[NCP][NetMoving][teleport] player=").append(player.getName())
+                    .append(" reason=").append(reason)
+                    .append(" ").append(data.describeMovingTeleportState(now, knownLocation, packetLocation, packetData))
+                    .toString());
+            player.getServer().getLogger().info(new StringBuilder(1100)
+                    .append("[NCP][NetMoving][model] player=").append(player.getName())
+                    .append(" reason=").append(reason)
+                    .append(" playerState=").append(formatPlayerState(player))
+                    .append(" movingData=").append(formatMovingData(mData, knownLocation))
+                    .append(" input=").append(formatKeyboardInput(mData.input))
+                    .append(" packetModel=").append(formatPacketModel(data, packetData, knownLocation, packetLocation, now))
+                    .toString());
+        }
+        catch (Throwable ignored) {}
+    }
+
+    private String formatPlayerState(final Player player) {
+        final Vector velocity = player.getVelocity();
+        return new StringBuilder(240)
+                .append("world=").append(player.getWorld() == null ? "null" : player.getWorld().getName())
+                .append(",gameMode=").append(player.getGameMode())
+                .append(",dead=").append(player.isDead())
+                .append(",health=").append(StringUtil.fdec3.format(player.getHealth()))
+                .append(",food=").append(player.getFoodLevel())
+                .append(",sprint=").append(player.isSprinting())
+                .append(",sneak=").append(player.isSneaking())
+                .append(",fly=").append(player.isFlying())
+                .append(",allowFlight=").append(player.getAllowFlight())
+                .append(",vehicle=").append(player.isInsideVehicle())
+                .append(",walkSpeed=").append(StringUtil.fdec3.format(player.getWalkSpeed()))
+                .append(",fall=").append(StringUtil.fdec3.format(player.getFallDistance()))
+                .append(",velocity=").append(formatVector(velocity.getX(), velocity.getY(), velocity.getZ()))
+                .toString();
+    }
+
+    private String formatMovingData(final MovingData data, final Location ref) {
+        final StringBuilder builder = new StringBuilder(700);
+        builder.append("{moveCount=").append(data.getPlayerMoveCount())
+                .append(",sfVL=").append(StringUtil.fdec3.format(data.survivalFlyVL))
+                .append(",sfJumpPhase=").append(data.sfJumpPhase)
+                .append(",liftOff=").append(data.liftOffEnvelope)
+                .append(",joinOrRespawn=").append(data.joinOrRespawn)
+                .append(",timeSinceSetBack=").append(data.timeSinceSetBack)
+                .append(",setBack=").append(data.hasSetBack() ? formatBukkitLocation(data.getSetBack(ref)) : "none")
+                .append(",morePacketsSetBack=").append(data.hasMorePacketsSetBack() ? formatBukkitLocation(data.getMorePacketsSetBack()) : "none")
+                .append(",teleported=").append(data.hasTeleported() ? formatBukkitLocation(data.getTeleported()) : "none")
+                .append(",speed=walk:").append(StringUtil.fdec3.format(data.walkSpeed))
+                .append("->").append(StringUtil.fdec3.format(data.nextWalkSpeed))
+                .append("/tick:").append(data.speedTick)
+                .append(",frictionH=").append(StringUtil.fdec3.format(data.lastFrictionHorizontal))
+                .append("->").append(StringUtil.fdec3.format(data.nextFrictionHorizontal))
+                .append(",stuckH=").append(StringUtil.fdec3.format(data.lastStuckInBlockHorizontal))
+                .append("->").append(StringUtil.fdec3.format(data.nextStuckInBlockHorizontal))
+                .append(",lastGravity=").append(StringUtil.fdec3.format(data.lastGravity))
+                .append(",nextGravity=").append(StringUtil.fdec3.format(data.nextGravity))
+                .append(",currentMove=").append(formatPlayerMove(data.playerMoves.getCurrentMove()))
+                .append(",lastMove=").append(formatPlayerMove(data.playerMoves.getFirstPastMove()))
+                .append('}');
+        return builder.toString();
+    }
+
+    private String formatPlayerMove(final PlayerMoveData move) {
+        final StringBuilder builder = new StringBuilder(500);
+        builder.append("{valid=").append(move.valid)
+                .append(",toValid=").append(move.toIsValid)
+                .append(",from=").append(formatLocationData(move.from));
+        if (move.toIsValid) {
+            builder.append(",to=").append(formatLocationData(move.to))
+                    .append(",actual=").append(formatVector(move.xDistance, move.yDistance, move.zDistance))
+                    .append(",h=").append(StringUtil.fdec3.format(move.hDistance))
+                    .append(",distSq=").append(StringUtil.fdec3.format(move.distanceSquared))
+                    .append(",allowed=").append(formatVector(move.xAllowedDistance, move.yAllowedDistance, move.zAllowedDistance))
+                    .append(",hAllowed=").append(StringUtil.fdec3.format(move.hAllowedDistance))
+                    .append(",over=").append(formatVector(move.xDistance - move.xAllowedDistance,
+                            move.yDistance - move.yAllowedDistance, move.zDistance - move.zAllowedDistance));
+        }
+        builder.append(",flyCheck=").append(move.flyCheck)
+                .append(",modelFlying=").append(move.modelFlying == null ? "none" : move.modelFlying.getClass().getSimpleName())
+                .append(",impulse=").append(move.hasImpulse).append('/').append(move.forwardImpulse).append('/').append(move.strafeImpulse)
+                .append(",collide=").append(move.collideX).append('/').append(move.collideY).append('/').append(move.collideZ)
+                .append(",hCollide=").append(move.collidesHorizontally)
+                .append(",minorHCollide=").append(move.negligibleHorizontalCollision)
+                .append(",touchedGround=").append(move.touchedGround)
+                .append(",lostGround=").append(move.fromLostGround).append('/').append(move.toLostGround)
+                .append(",jump=").append(move.isJump)
+                .append(",step=").append(move.isStepUp)
+                .append(",multi=").append(move.multiMoveCount)
+                .append(",hidden=").append(move.hiddenDistanceIndex).append('/').append(move.hiddenYDistanceIndex)
+                .append(",correctedPre=").append(formatVector(move.xCorrectedDistancePre, move.yCorrectedDistancePre, move.zCorrectedDistancePre))
+                .append(",correctedPost=").append(formatVector(move.xCorrectedDistancePost, 0.0, move.zCorrectedDistancePost))
+                .append(",verVelUsed=").append(move.verVelUsed)
+                .append('}');
+        return builder.toString();
+    }
+
+    private String formatPacketModel(final NetData data, final DataPacketFlying packetData,
+                                     final Location knownLocation, final Location packetLocation,
+                                     final long now) {
+        final DataPacketFlying[] flyingQueue = data.copyFlyingQueue();
+        final DataPacketInput[] inputQueue = data.copyInputQueue();
+        return new StringBuilder(900)
+                .append("{queueSize=").append(flyingQueue.length)
+                .append(",inputQueueSize=").append(inputQueue.length)
+                .append(",lastMatchedMoveToSeq=").append(data.getLastMatchedMoveToSequence())
+                .append(",currentPacketSeq=").append(packetData == null ? -1L : packetData.getSequence())
+                .append(",clientMotion=").append(formatClientMotion(flyingQueue))
+                .append(",knownFromPreviousPacket=").append(formatKnownFromPreviousPacket(flyingQueue, knownLocation))
+                .append(",packetFromKnown=").append(formatLocationDelta(knownLocation, packetLocation))
+                .append(",recentPackets=").append(formatFlyingQueue(flyingQueue, now))
+                .append(",recentInputs=").append(formatInputQueue(inputQueue))
+                .append('}')
+                .toString();
+    }
+
+    private String formatClientMotion(final DataPacketFlying[] queue) {
+        if (queue.length < 2 || !queue[0].hasPos || !queue[1].hasPos) {
+            return "none";
+        }
+        return formatPacketDelta(queue[1], queue[0]);
+    }
+
+    private String formatKnownFromPreviousPacket(final DataPacketFlying[] queue, final Location knownLocation) {
+        if (queue.length < 2 || !queue[1].hasPos) {
+            return "none";
+        }
+        return formatPositionDelta(queue[1].getX(), queue[1].getY(), queue[1].getZ(),
+                knownLocation.getX(), knownLocation.getY(), knownLocation.getZ());
+    }
+
+    private String formatFlyingQueue(final DataPacketFlying[] queue, final long now) {
+        if (queue.length == 0) {
+            return "[]";
+        }
+        final StringBuilder builder = new StringBuilder(500);
+        builder.append('[');
+        final int max = Math.min(queue.length, 6);
+        for (int i = 0; i < max; i++) {
+            if (i > 0) {
+                builder.append(';');
+            }
+            builder.append(formatPacket(queue[i], now));
+            if (i + 1 < queue.length && queue[i].hasPos && queue[i + 1].hasPos) {
+                builder.append(",dPrev=").append(formatPacketDelta(queue[i + 1], queue[i]));
+            }
+        }
+        if (queue.length > max) {
+            builder.append(";...");
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+
+    private String formatInputQueue(final DataPacketInput[] queue) {
+        if (queue.length == 0) {
+            return "[]";
+        }
+        final StringBuilder builder = new StringBuilder(220);
+        builder.append('[');
+        final int max = Math.min(queue.length, 6);
+        for (int i = 0; i < max; i++) {
+            if (i > 0) {
+                builder.append(';');
+            }
+            builder.append(formatInput(queue[i]));
+        }
+        if (queue.length > max) {
+            builder.append(";...");
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+
+    private String formatPacket(final DataPacketFlying packetData, final long now) {
+        if (packetData == null) {
+            return "null";
+        }
+        final StringBuilder builder = new StringBuilder(220);
+        builder.append("{seq=").append(packetData.getSequence())
+                .append(",age=").append(now >= packetData.time ? now - packetData.time : -(packetData.time - now))
+                .append(",type=").append(packetData.getSimplifiedContentType())
+                .append(",tracked=").append(packetData.isTracked())
+                .append(",ground=").append(packetData.onGround)
+                .append(",hCollision=").append(packetData.horizontalCollision);
+        if (packetData.hasPos) {
+            builder.append(",pos=").append(formatVector(packetData.getX(), packetData.getY(), packetData.getZ()));
+        }
+        if (packetData.hasLook) {
+            builder.append(",look=").append(StringUtil.fdec3.format(packetData.getYaw()))
+                    .append('/').append(StringUtil.fdec3.format(packetData.getPitch()));
+        }
+        builder.append('}');
+        return builder.toString();
+    }
+
+    private String formatKeyboardInput(final PlayerKeyboardInput input) {
+        return new StringBuilder(120)
+                .append("current=").append(input.getForwardDir()).append('/').append(input.getStrafeDir())
+                .append('(').append(StringUtil.fdec3.format(input.getForward())).append('/')
+                .append(StringUtil.fdec3.format(input.getStrafe())).append(')')
+                .append(",last=(").append(StringUtil.fdec3.format(input.getLastForward())).append('/')
+                .append(StringUtil.fdec3.format(input.getLastStrafe())).append(')')
+                .append(",keys=jump:").append(input.isSpaceBarPressed()).append("->").append(input.wasSpaceBarPressed())
+                .append(",sneak:").append(input.isShift()).append("->").append(input.wasShifting())
+                .append(",sprint:").append(input.isSprintingKeyPressed()).append("->").append(input.wasSprintingKeyPressed())
+                .toString();
+    }
+
+    private String formatInput(final DataPacketInput input) {
+        if (input == null) {
+            return "none";
+        }
+        return new StringBuilder(80)
+                .append("f:").append(input.forward)
+                .append(",b:").append(input.backward)
+                .append(",l:").append(input.left)
+                .append(",r:").append(input.right)
+                .append(",j:").append(input.jump)
+                .append(",shift:").append(input.shift)
+                .append(",sprint:").append(input.sprint)
+                .toString();
+    }
+
+    private String formatPacketDelta(final DataPacketFlying from, final DataPacketFlying to) {
+        return formatPositionDelta(from.getX(), from.getY(), from.getZ(), to.getX(), to.getY(), to.getZ());
+    }
+
+    private String formatLocationDelta(final Location from, final Location to) {
+        return formatPositionDelta(from.getX(), from.getY(), from.getZ(), to.getX(), to.getY(), to.getZ());
+    }
+
+    private String formatPositionDelta(final double fromX, final double fromY, final double fromZ,
+                                       final double toX, final double toY, final double toZ) {
+        final double xDistance = toX - fromX;
+        final double yDistance = toY - fromY;
+        final double zDistance = toZ - fromZ;
+        final double hDistance = Math.sqrt(xDistance * xDistance + zDistance * zDistance);
+        final double total = Math.sqrt(hDistance * hDistance + yDistance * yDistance);
+        return new StringBuilder(120)
+                .append("x=").append(StringUtil.fdec3.format(xDistance))
+                .append(",y=").append(StringUtil.fdec3.format(yDistance))
+                .append(",z=").append(StringUtil.fdec3.format(zDistance))
+                .append(",h=").append(StringUtil.fdec3.format(hDistance))
+                .append(",total=").append(StringUtil.fdec3.format(total))
+                .toString();
+    }
+
+    private String formatLocationData(final LocationData loc) {
+        final StringBuilder builder = new StringBuilder(140);
+        builder.append(loc.getWorldName()).append('@').append(LocUtil.simpleFormat(loc));
+        if (loc.extraPropertiesValid) {
+            builder.append(",ground=").append(loc.onGround)
+                    .append(",reset=").append(loc.resetCond)
+                    .append(",liquid=").append(loc.inLiquid)
+                    .append(",web=").append(loc.inWeb)
+                    .append(",powder=").append(loc.inPowderSnow)
+                    .append(",ice=").append(loc.onIce || loc.onBlueIce)
+                    .append(",slime=").append(loc.onSlimeBlock)
+                    .append(",honey=").append(loc.onHoneyBlock);
+        }
+        else {
+            builder.append(",flags=unknown");
+        }
+        return builder.toString();
+    }
+
+    private String formatBukkitLocation(final Location loc) {
+        return loc == null ? "null" : (loc.getWorld() == null ? "null" : loc.getWorld().getName()) + '@' + LocUtil.simpleFormat(loc);
+    }
+
+    private String formatVector(final double x, final double y, final double z) {
+        return StringUtil.fdec3.format(x) + "," + StringUtil.fdec3.format(y) + "," + StringUtil.fdec3.format(z);
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
@@ -15,6 +15,7 @@
 package fr.neatmonster.nocheatplus.checks.net;
 
 import java.util.LinkedList;
+import java.util.Iterator;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -49,6 +50,25 @@ import fr.neatmonster.nocheatplus.utilities.location.LocUtil;
  */
 public class NetData extends ACheckData {
 
+    private static final long MOVING_TELEPORT_GRACE_MS = 4000L;
+    private static final long MOVING_SERVER_JUMP_RECOVERY_GRACE_MS = 1500L;
+    private static final double MOVING_POSITION_MATCH_EPSILON = 0.03125D;
+    private static final double MOVING_SERVER_JUMP_DISTANCE = 100.0D;
+    private static final double MOVING_SERVER_JUMP_PACKET_DISTANCE = 64.0D;
+    private static final long MOVING_SERVER_JUMP_STALE_PACKET_MODEL_MS = 4000L;
+    private static final double MOVING_SERVER_JUMP_TARGET_MODEL_DISTANCE = 8.0D;
+    private static final double MOVING_STALE_PACKET_HORIZONTAL_BASE = 1.25D;
+    private static final double MOVING_STALE_PACKET_VERTICAL_BASE = 0.75D;
+    private static final double MOVING_STALE_PACKET_VERTICAL_PER_TICK = 0.30D;
+    private static final double MOVING_STALE_PACKET_VERTICAL_MAX = 4.0D;
+    private static final double MOVING_STALE_PACKET_MOTION_MULTIPLIER = 3.0D;
+    private static final long MOVING_TELEPORT_COMMAND_PENDING_MS = 15000L;
+    private static final long MOVING_TELEPORT_RESYNC_PENDING_MS = 4000L;
+    private static final double MOVING_TELEPORT_RESYNC_TARGET_DISTANCE = 8.0D;
+    private static final int MOVING_TELEPORT_RESYNC_NORMAL_STALE_PACKET_LIMIT = 2;
+    private static final long KEEP_ALIVE_REQUEST_MAX_AGE_MS = 30000L;
+    private static final int KEEP_ALIVE_REQUEST_MAX_PENDING = 40;
+
     // Reentrant lock.
     private final Lock lock = new ReentrantLock();
     private final Lock locki = new ReentrantLock();
@@ -62,6 +82,65 @@ public class NetData extends ACheckData {
 
     // Moving
     public double movingVL = 0;
+    // NetMoving diagnostics/model state: remember teleport and server-position packets for packet-order false flags.
+    private long lastMovingTeleportTime = 0L;
+    private String lastMovingTeleportWorld = null;
+    private String lastMovingTeleportCause = "none";
+    private double lastMovingTeleportX = 0.0;
+    private double lastMovingTeleportY = 0.0;
+    private double lastMovingTeleportZ = 0.0;
+    private float lastMovingTeleportYaw = 0.0f;
+    private float lastMovingTeleportPitch = 0.0f;
+    private long lastOutgoingPositionTime = 0L;
+    private boolean lastOutgoingPositionTracked = false;
+    private int lastOutgoingPositionTeleportId = Integer.MIN_VALUE;
+    private double lastOutgoingPositionX = 0.0;
+    private double lastOutgoingPositionY = 0.0;
+    private double lastOutgoingPositionZ = 0.0;
+    private float lastOutgoingPositionYaw = 0.0f;
+    private float lastOutgoingPositionPitch = 0.0f;
+    private long lastMovingKnownLocationTime = 0L;
+    private String lastMovingKnownLocationWorld = null;
+    private double lastMovingKnownLocationX = 0.0;
+    private double lastMovingKnownLocationY = 0.0;
+    private double lastMovingKnownLocationZ = 0.0;
+    private float lastMovingKnownLocationYaw = 0.0f;
+    private float lastMovingKnownLocationPitch = 0.0f;
+    private long lastServerPositionJumpTime = 0L;
+    private String lastServerPositionJumpFromWorld = null;
+    private String lastServerPositionJumpToWorld = null;
+    private double lastServerPositionJumpFromX = 0.0;
+    private double lastServerPositionJumpFromY = 0.0;
+    private double lastServerPositionJumpFromZ = 0.0;
+    private float lastServerPositionJumpFromYaw = 0.0f;
+    private float lastServerPositionJumpFromPitch = 0.0f;
+    private double lastServerPositionJumpToX = 0.0;
+    private double lastServerPositionJumpToY = 0.0;
+    private double lastServerPositionJumpToZ = 0.0;
+    private float lastServerPositionJumpToYaw = 0.0f;
+    private float lastServerPositionJumpToPitch = 0.0f;
+    private long lastServerPositionJumpRecoveryUsedTime = 0L;
+    private long lastTeleportCommandTime = 0L;
+    private String lastTeleportCommand = "none";
+    private String lastTeleportCommandWorld = null;
+    private double lastTeleportCommandX = 0.0;
+    private double lastTeleportCommandY = 0.0;
+    private double lastTeleportCommandZ = 0.0;
+    private float lastTeleportCommandYaw = 0.0f;
+    private float lastTeleportCommandPitch = 0.0f;
+    private long lastTeleportResyncMovingDataKey = 0L;
+    private long lastTeleportResyncRequestTime = 0L;
+    private long lastTeleportResyncAppliedKey = 0L;
+    private String lastTeleportResyncReason = "none";
+    private String lastTeleportResyncWorld = null;
+    private double lastTeleportResyncX = 0.0;
+    private double lastTeleportResyncY = 0.0;
+    private double lastTeleportResyncZ = 0.0;
+    private float lastTeleportResyncYaw = 0.0f;
+    private float lastTeleportResyncPitch = 0.0f;
+    private long lastTeleportResyncDroppedPacketLogTime = 0L;
+    private int lastTeleportResyncDroppedPacketCount = 0;
+    private int lastTeleportResyncPendingDropLogCount = 0;
 
     // KeepAliveFrequency
     /**
@@ -69,6 +148,34 @@ public class NetData extends ACheckData {
      * time of the last event. System.currentTimeMillis() is used.
      */
     public ActionFrequency keepAliveFreq = new ActionFrequency(20, 1000);
+    public long keepAlivePacketTime = 0L;
+    public long keepAlivePreviousPacketTime = 0L;
+    public long keepAlivePacketDelta = -1L;
+    public long keepAlivePacketId = 0L;
+    public long keepAlivePreviousPacketId = 0L;
+    public boolean keepAlivePacketIdAvailable = false;
+    public boolean keepAlivePreviousPacketIdAvailable = false;
+    public boolean keepAliveDuplicateId = false;
+    // KeepAlive diagnostics: record packet shape/thread so async Folia timing is visible in console logs.
+    public String keepAlivePacketIdType = "none";
+    public int keepAlivePacketLongCount = -1;
+    public int keepAlivePacketIntCount = -1;
+    public boolean keepAlivePacketAsync = false;
+    public String keepAlivePacketThread = "unknown";
+    // KeepAlive model: expected client replies should match a recent outgoing server keepalive id.
+    private final LinkedList<KeepAliveRequest> keepAliveRequests = new LinkedList<KeepAliveRequest>();
+    public boolean keepAliveOutgoingSeen = false;
+    public long keepAliveOutgoingPacketTime = 0L;
+    public long keepAliveOutgoingPacketId = 0L;
+    public boolean keepAliveOutgoingPacketIdAvailable = false;
+    public String keepAliveOutgoingPacketIdType = "none";
+    public int keepAliveOutgoingPacketLongCount = -1;
+    public int keepAliveOutgoingPacketIntCount = -1;
+    public boolean keepAliveOutgoingPacketAsync = false;
+    public String keepAliveOutgoingPacketThread = "unknown";
+    public boolean keepAliveExpectedResponse = false;
+    public long keepAliveExpectedResponseAge = -1L;
+    public int keepAlivePendingRequests = 0;
 	
     // Wrong Turn
     public double wrongTurnVL = 0;
@@ -123,13 +230,736 @@ public class NetData extends ACheckData {
     }
 
     public void onJoin(final Player player) {
+        resetMovingTeleportDiagnostics();
         teleportQueue.clear();
         clearFlyingQueue();
+        clearKeepAliveTracking();
     }
 
     public void onLeave(Player player) {
+        resetMovingTeleportDiagnostics();
         teleportQueue.clear();
         clearFlyingQueue();
+        clearKeepAliveTracking();
+    }
+
+    /**
+     * Register a Bukkit teleport for packet-level moving checks.
+     */
+    public void recordTeleportEvent(final Location loc) {
+        recordTeleportEvent(loc, "unknown");
+    }
+
+    /**
+     * Register a Bukkit teleport for packet-level moving checks.
+     */
+    public void recordTeleportEvent(final Location loc, final String cause) {
+        lastMovingTeleportTime = System.currentTimeMillis();
+        lastMovingTeleportCause = cause == null ? "unknown" : cause;
+        movingVL *= 0.5;
+        clearFlyingQueue();
+        if (loc != null) {
+            lastMovingTeleportWorld = loc.getWorld() == null ? "null" : loc.getWorld().getName();
+            lastMovingTeleportX = loc.getX();
+            lastMovingTeleportY = loc.getY();
+            lastMovingTeleportZ = loc.getZ();
+            lastMovingTeleportYaw = loc.getYaw();
+            lastMovingTeleportPitch = loc.getPitch();
+            teleportQueue.onTeleportEvent(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
+        }
+    }
+
+    /**
+     * Register every outgoing server position packet, including ones not matched
+     * to a Bukkit PlayerTeleportEvent. This catches packet/event ordering races.
+     */
+    public void recordOutgoingPosition(final double x, final double y, final double z,
+                                       final float yaw, final float pitch,
+                                       final int teleportId, final boolean tracked,
+                                       final long time) {
+        lastOutgoingPositionTime = time;
+        lastOutgoingPositionTracked = tracked;
+        lastOutgoingPositionTeleportId = teleportId;
+        lastOutgoingPositionX = x;
+        lastOutgoingPositionY = y;
+        lastOutgoingPositionZ = z;
+        lastOutgoingPositionYaw = yaw;
+        lastOutgoingPositionPitch = pitch;
+    }
+
+    public void recordKeepAlivePacket(final long time, final boolean idAvailable, final long id,
+                                      final String idType, final int longCount, final int intCount,
+                                      final boolean async, final String threadName) {
+        keepAlivePreviousPacketTime = keepAlivePacketTime;
+        keepAlivePreviousPacketId = keepAlivePacketId;
+        keepAlivePreviousPacketIdAvailable = keepAlivePacketIdAvailable;
+        keepAlivePacketDelta = keepAlivePreviousPacketTime <= 0L ? -1L : time - keepAlivePreviousPacketTime;
+        keepAlivePacketTime = time;
+        keepAlivePacketIdAvailable = idAvailable;
+        keepAlivePacketId = id;
+        keepAlivePacketIdType = idType == null ? "none" : idType;
+        keepAlivePacketLongCount = longCount;
+        keepAlivePacketIntCount = intCount;
+        keepAlivePacketAsync = async;
+        keepAlivePacketThread = threadName == null ? "unknown" : threadName;
+        keepAliveDuplicateId = idAvailable && keepAlivePreviousPacketIdAvailable && id == keepAlivePreviousPacketId;
+        keepAliveExpectedResponse = false;
+        keepAliveExpectedResponseAge = -1L;
+        synchronized (keepAliveRequests) {
+            pruneKeepAliveRequests(time);
+            if (idAvailable) {
+                final Iterator<KeepAliveRequest> iterator = keepAliveRequests.iterator();
+                while (iterator.hasNext()) {
+                    final KeepAliveRequest request = iterator.next();
+                    if (request.id == id) {
+                        keepAliveExpectedResponse = true;
+                        keepAliveExpectedResponseAge = Math.max(0L, time - request.time);
+                        iterator.remove();
+                        break;
+                    }
+                }
+            }
+            keepAlivePendingRequests = keepAliveRequests.size();
+        }
+    }
+
+    public void recordOutgoingKeepAlivePacket(final long time, final boolean idAvailable, final long id,
+                                             final String idType, final int longCount, final int intCount,
+                                             final boolean async, final String threadName) {
+        keepAliveOutgoingSeen = true;
+        keepAliveOutgoingPacketTime = time;
+        keepAliveOutgoingPacketIdAvailable = idAvailable;
+        keepAliveOutgoingPacketId = id;
+        keepAliveOutgoingPacketIdType = idType == null ? "none" : idType;
+        keepAliveOutgoingPacketLongCount = longCount;
+        keepAliveOutgoingPacketIntCount = intCount;
+        keepAliveOutgoingPacketAsync = async;
+        keepAliveOutgoingPacketThread = threadName == null ? "unknown" : threadName;
+        synchronized (keepAliveRequests) {
+            pruneKeepAliveRequests(time);
+            if (idAvailable) {
+                keepAliveRequests.addFirst(new KeepAliveRequest(time, id));
+                while (keepAliveRequests.size() > KEEP_ALIVE_REQUEST_MAX_PENDING) {
+                    keepAliveRequests.removeLast();
+                }
+            }
+            keepAlivePendingRequests = keepAliveRequests.size();
+        }
+    }
+
+    private void pruneKeepAliveRequests(final long time) {
+        while (!keepAliveRequests.isEmpty()
+                && time - keepAliveRequests.getLast().time > KEEP_ALIVE_REQUEST_MAX_AGE_MS) {
+            keepAliveRequests.removeLast();
+        }
+    }
+
+    private void clearKeepAliveTracking() {
+        synchronized (keepAliveRequests) {
+            keepAliveRequests.clear();
+            keepAlivePendingRequests = 0;
+        }
+        keepAliveOutgoingSeen = false;
+        keepAliveOutgoingPacketTime = 0L;
+        keepAliveOutgoingPacketId = 0L;
+        keepAliveOutgoingPacketIdAvailable = false;
+        keepAliveOutgoingPacketIdType = "none";
+        keepAliveOutgoingPacketLongCount = -1;
+        keepAliveOutgoingPacketIntCount = -1;
+        keepAliveOutgoingPacketAsync = false;
+        keepAliveOutgoingPacketThread = "unknown";
+        keepAliveExpectedResponse = false;
+        keepAliveExpectedResponseAge = -1L;
+    }
+
+    /**
+     * Track the server-side player location seen by NET_MOVING. If it suddenly
+     * jumps far away, stale client packets near the previous server location are
+     * very likely plugin-teleport leftovers.
+     */
+    public void recordMovingKnownLocation(final Location loc, final long now) {
+        if (loc == null) {
+            return;
+        }
+        final String world = loc.getWorld() == null ? "null" : loc.getWorld().getName();
+        if (lastMovingKnownLocationTime > 0L) {
+            final boolean worldChanged = lastMovingKnownLocationWorld == null
+                || !lastMovingKnownLocationWorld.equals(world);
+            final double distance = distance(lastMovingKnownLocationX, lastMovingKnownLocationY, lastMovingKnownLocationZ,
+                    loc.getX(), loc.getY(), loc.getZ());
+            if (worldChanged || distance > MOVING_SERVER_JUMP_DISTANCE) {
+                lastServerPositionJumpTime = now;
+                lastServerPositionJumpFromWorld = lastMovingKnownLocationWorld;
+                lastServerPositionJumpFromX = lastMovingKnownLocationX;
+                lastServerPositionJumpFromY = lastMovingKnownLocationY;
+                lastServerPositionJumpFromZ = lastMovingKnownLocationZ;
+                lastServerPositionJumpFromYaw = lastMovingKnownLocationYaw;
+                lastServerPositionJumpFromPitch = lastMovingKnownLocationPitch;
+                lastServerPositionJumpToWorld = world;
+                lastServerPositionJumpToX = loc.getX();
+                lastServerPositionJumpToY = loc.getY();
+                lastServerPositionJumpToZ = loc.getZ();
+                lastServerPositionJumpToYaw = loc.getYaw();
+                lastServerPositionJumpToPitch = loc.getPitch();
+            }
+        }
+        lastMovingKnownLocationTime = now;
+        lastMovingKnownLocationWorld = world;
+        lastMovingKnownLocationX = loc.getX();
+        lastMovingKnownLocationY = loc.getY();
+        lastMovingKnownLocationZ = loc.getZ();
+        lastMovingKnownLocationYaw = loc.getYaw();
+        lastMovingKnownLocationPitch = loc.getPitch();
+    }
+
+    /**
+     * Mark that a command likely to teleport the player has been issued.
+     */
+    public void recordTeleportCommand(final String command, final Location loc, final long now) {
+        lastTeleportCommandTime = now;
+        lastTeleportCommand = command == null ? "unknown" : command;
+        if (loc != null) {
+            lastTeleportCommandWorld = loc.getWorld() == null ? "null" : loc.getWorld().getName();
+            lastTeleportCommandX = loc.getX();
+            lastTeleportCommandY = loc.getY();
+            lastTeleportCommandZ = loc.getZ();
+            lastTeleportCommandYaw = loc.getYaw();
+            lastTeleportCommandPitch = loc.getPitch();
+        }
+    }
+
+    public boolean isWithinMovingTeleportGrace(final long now) {
+        return lastMovingTeleportTime > 0L
+            && now >= lastMovingTeleportTime
+            && now - lastMovingTeleportTime <= MOVING_TELEPORT_GRACE_MS;
+    }
+
+    public boolean isWithinOutgoingPositionGrace(final long now, final Location knownLocation) {
+        return lastOutgoingPositionTime > 0L
+            && now >= lastOutgoingPositionTime
+            && now - lastOutgoingPositionTime <= MOVING_TELEPORT_GRACE_MS
+            && matchesPosition(lastOutgoingPositionX, lastOutgoingPositionY, lastOutgoingPositionZ, knownLocation);
+    }
+
+    public boolean consumeExpectedOutgoingPosition(final DataPacketFlying packetData) {
+        // Folia/respawn compatibility: the move can arrive before the outgoing teleport packet is recorded.
+        return teleportQueue.consumeExpectedOutgoingPosition(packetData);
+    }
+
+    public boolean isWithinServerPositionJumpGrace(final long now, final Location knownLocation, final Location packetLocation) {
+        return lastServerPositionJumpTime > 0L
+            && now >= lastServerPositionJumpTime
+            && now - lastServerPositionJumpTime <= MOVING_TELEPORT_GRACE_MS
+            && distanceToStored(lastServerPositionJumpToX, lastServerPositionJumpToY, lastServerPositionJumpToZ, knownLocation) <= MOVING_SERVER_JUMP_PACKET_DISTANCE
+            && distanceToStored(lastServerPositionJumpFromX, lastServerPositionJumpFromY, lastServerPositionJumpFromZ, packetLocation) <= MOVING_SERVER_JUMP_PACKET_DISTANCE;
+    }
+
+    public boolean isWithinServerPositionJumpStalePacketModel(final long now,
+                                                              final Location knownLocation,
+                                                              final Location packetLocation,
+                                                              final DataPacketFlying packetData) {
+        // Teleport model: Folia/async teleports can leave pre-teleport packets in flight after the server moved.
+        return lastServerPositionJumpTime > 0L
+            && now >= lastServerPositionJumpTime
+            && now - lastServerPositionJumpTime <= MOVING_SERVER_JUMP_STALE_PACKET_MODEL_MS
+            && distanceToStored(lastServerPositionJumpToX, lastServerPositionJumpToY, lastServerPositionJumpToZ,
+                    knownLocation) <= MOVING_SERVER_JUMP_TARGET_MODEL_DISTANCE
+            && isStalePacketNearStoredPositionModel(packetLocation, packetData,
+                    lastServerPositionJumpFromX, lastServerPositionJumpFromY, lastServerPositionJumpFromZ,
+                    now - lastServerPositionJumpTime);
+    }
+
+    public boolean consumeServerPositionJumpRecoveryGrace(final long now, final Location knownLocation) {
+        // Folia/death compatibility: allow one stale packet after a server-side jump even if it matches neither endpoint.
+        if (lastServerPositionJumpTime <= 0L
+                || now < lastServerPositionJumpTime
+                || now - lastServerPositionJumpTime > MOVING_SERVER_JUMP_RECOVERY_GRACE_MS
+                || lastServerPositionJumpRecoveryUsedTime == lastServerPositionJumpTime
+                || distanceToStored(lastServerPositionJumpToX, lastServerPositionJumpToY, lastServerPositionJumpToZ, knownLocation) > MOVING_SERVER_JUMP_PACKET_DISTANCE) {
+            return false;
+        }
+        lastServerPositionJumpRecoveryUsedTime = lastServerPositionJumpTime;
+        return true;
+    }
+
+    public boolean isWithinTeleportCommandGrace(final long now, final Location knownLocation, final Location packetLocation) {
+        return lastTeleportCommandTime > 0L
+            && now >= lastTeleportCommandTime
+            && now - lastTeleportCommandTime <= MOVING_TELEPORT_COMMAND_PENDING_MS
+            && distanceToStored(lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ, knownLocation) > MOVING_SERVER_JUMP_DISTANCE
+            && distanceToStored(lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ, packetLocation) <= MOVING_SERVER_JUMP_PACKET_DISTANCE;
+    }
+
+    public boolean isWithinTeleportCommandStalePacketModel(final long now,
+                                                          final Location knownLocation,
+                                                          final Location packetLocation,
+                                                          final DataPacketFlying packetData) {
+        // Teleport command model: command plugins can async-teleport before Bukkit's event/order data is visible here.
+        return lastTeleportCommandTime > 0L
+            && now >= lastTeleportCommandTime
+            && now - lastTeleportCommandTime <= MOVING_TELEPORT_COMMAND_PENDING_MS
+            && distanceToStored(lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ,
+                    knownLocation) > MOVING_SERVER_JUMP_DISTANCE
+            && isStalePacketNearStoredPositionModel(packetLocation, packetData,
+                    lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ,
+                    now - lastTeleportCommandTime);
+    }
+
+    public void acceptMovingTeleportResync(final Player player, final Plugin plugin, final MovingData mData,
+                                           final Location knownLocation, final Location packetLocation,
+                                           final DataPacketFlying packetData, final long now, final String reason) {
+        // Teleport model: accepted stale packets are packet-order leftovers, not valid post-teleport history.
+        movingVL *= 0.5;
+        final int queueSizeBeforeClear = getFlyingQueueSize();
+        clearFlyingQueue();
+        if (player == null || plugin == null || mData == null || knownLocation == null
+                || knownLocation.getWorld() == null) {
+            return;
+        }
+        final Location modelLocation = LocUtil.clone(knownLocation);
+        final long resyncKey = Math.max(lastServerPositionJumpTime, lastTeleportCommandTime);
+        if (resyncKey <= 0L || lastTeleportResyncMovingDataKey == resyncKey) {
+            return;
+        }
+        lastTeleportResyncMovingDataKey = resyncKey;
+        recordPendingTeleportResync(resyncKey, modelLocation, now, reason);
+        logTeleportResyncStalePacketDrop(player, now, modelLocation, packetLocation, packetData,
+                reason, "opened", queueSizeBeforeClear, true);
+        final Object task = SchedulerHelper.runSyncTaskForEntity(player, plugin, (arg) -> {
+            if (lastTeleportResyncAppliedKey == resyncKey) {
+                return;
+            }
+            Location syncLocation = null;
+            try {
+                syncLocation = player.isOnline() ? player.getLocation() : null;
+            }
+            catch (Throwable ignored) {}
+            // Folia model sync: refresh MovingData only on the player's owning region thread.
+            mData.onExternalTeleportResync(syncLocation != null && syncLocation.getWorld() != null
+                    ? syncLocation : modelLocation);
+            markTeleportResyncApplied(resyncKey);
+            if (shouldLogTeleportResyncSuccessToConsole()) {
+                player.getServer().getLogger().info(NetDiagnostics.formatTeleportResyncApplied(player.getName(),
+                        "applied", reason, lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                        lastTeleportResyncYaw, lastTeleportResyncPitch));
+            }
+        }, null);
+        if (!SchedulerHelper.isTaskScheduled(task)) {
+            StaticLog.logWarning("Failed to schedule teleport resync moving-data refresh for player: "
+                    + player.getName() + " (" + (reason == null ? "unknown" : reason) + ")");
+        }
+    }
+
+    public boolean isWithinTeleportResyncStalePacketDropModel(final long now,
+                                                              final Location knownLocation,
+                                                              final Location packetLocation,
+                                                              final DataPacketFlying packetData) {
+        if (lastTeleportResyncMovingDataKey <= 0L
+                || lastTeleportResyncRequestTime <= 0L
+                || now < lastTeleportResyncRequestTime
+                || now - lastTeleportResyncRequestTime > MOVING_TELEPORT_RESYNC_PENDING_MS
+                || distanceToStored(lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                        knownLocation) > MOVING_TELEPORT_RESYNC_TARGET_DISTANCE) {
+            return false;
+        }
+        final long serverJumpAge = lastServerPositionJumpTime <= 0L ? Long.MAX_VALUE : now - lastServerPositionJumpTime;
+        if (lastServerPositionJumpTime > 0L
+                && serverJumpAge >= 0L
+                && serverJumpAge <= MOVING_SERVER_JUMP_STALE_PACKET_MODEL_MS
+                && isStalePacketNearStoredPositionModel(packetLocation, packetData,
+                        lastServerPositionJumpFromX, lastServerPositionJumpFromY,
+                        lastServerPositionJumpFromZ, serverJumpAge)) {
+            return true;
+        }
+        final long commandAge = lastTeleportCommandTime <= 0L ? Long.MAX_VALUE : now - lastTeleportCommandTime;
+        return lastTeleportCommandTime > 0L
+                && commandAge >= 0L
+                && commandAge <= MOVING_TELEPORT_COMMAND_PENDING_MS
+                && isStalePacketNearStoredPositionModel(packetLocation, packetData,
+                        lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ, commandAge);
+    }
+
+    public void acceptMovingTeleportStalePacketContinuation(final Player player,
+                                                            final Location knownLocation,
+                                                            final Location packetLocation,
+                                                            final DataPacketFlying packetData,
+                                                            final long now,
+                                                            final String reason) {
+        // Teleport model: additional old-location packets after resync are deleted from packet history.
+        movingVL *= 0.5;
+        final int queueSizeBeforeClear = getFlyingQueueSize();
+        clearFlyingQueue();
+        logTeleportResyncStalePacketDrop(player, now, knownLocation, packetLocation, packetData,
+                reason, "continuation", queueSizeBeforeClear, false);
+    }
+
+    /**
+     * Apply a pending teleport resync from the player move path, where MovingData
+     * is owned by the correct Folia region. This prevents stale pre-teleport
+     * set backs from surviving until the next scheduled entity task.
+     */
+    public boolean applyPendingTeleportResync(final Player player, final MovingData mData,
+                                              final Location eventFrom, final Location eventTo,
+                                              final long now) {
+        if (player == null || mData == null || lastTeleportResyncMovingDataKey <= 0L
+                || lastTeleportResyncAppliedKey == lastTeleportResyncMovingDataKey
+                || lastTeleportResyncRequestTime <= 0L
+                || now < lastTeleportResyncRequestTime
+                || now - lastTeleportResyncRequestTime > MOVING_TELEPORT_RESYNC_PENDING_MS) {
+            return false;
+        }
+        final Location modelTarget = getPendingTeleportResyncTarget();
+        if (modelTarget == null) {
+            return false;
+        }
+        Location current = null;
+        try {
+            current = player.isOnline() ? player.getLocation() : null;
+        }
+        catch (Throwable ignored) {}
+        final Location appliedTarget = isWorldBackedPendingTeleportTarget(current) ? current
+                : isWorldBackedPendingTeleportTarget(eventTo) ? eventTo
+                : isWorldBackedPendingTeleportTarget(eventFrom) ? eventFrom
+                : null;
+        if (appliedTarget == null) {
+            return false;
+        }
+        // Teleport/Folia model: move-event code is region-safe, so clear old movement history immediately.
+        mData.onExternalTeleportResync(appliedTarget);
+        markTeleportResyncApplied(lastTeleportResyncMovingDataKey);
+        if (shouldLogTeleportResyncSuccessToConsole()) {
+            player.getServer().getLogger().info(NetDiagnostics.formatTeleportResyncApplied(player.getName(),
+                    "applied_move_event", lastTeleportResyncReason,
+                    lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                    lastTeleportResyncYaw, lastTeleportResyncPitch));
+        }
+        return true;
+    }
+
+    private void recordPendingTeleportResync(final long resyncKey, final Location loc,
+                                             final long now, final String reason) {
+        lastTeleportResyncRequestTime = now;
+        lastTeleportResyncReason = reason == null ? "unknown" : reason;
+        lastTeleportResyncWorld = loc.getWorld() == null ? "null" : loc.getWorld().getName();
+        lastTeleportResyncX = loc.getX();
+        lastTeleportResyncY = loc.getY();
+        lastTeleportResyncZ = loc.getZ();
+        lastTeleportResyncYaw = loc.getYaw();
+        lastTeleportResyncPitch = loc.getPitch();
+        if (lastTeleportResyncAppliedKey != resyncKey) {
+            lastTeleportResyncAppliedKey = 0L;
+        }
+        lastTeleportResyncDroppedPacketLogTime = 0L;
+        lastTeleportResyncDroppedPacketCount = 0;
+        lastTeleportResyncPendingDropLogCount = 0;
+    }
+
+    private void markTeleportResyncApplied(final long resyncKey) {
+        if (resyncKey > 0L) {
+            lastTeleportResyncAppliedKey = resyncKey;
+        }
+    }
+
+    private Location getPendingTeleportResyncTarget() {
+        if (lastTeleportResyncMovingDataKey <= 0L || lastTeleportResyncWorld == null) {
+            return null;
+        }
+        return new Location(null, lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                lastTeleportResyncYaw, lastTeleportResyncPitch);
+    }
+
+    private boolean isNearPendingTeleportTarget(final Location loc) {
+        if (loc == null) {
+            return false;
+        }
+        if (loc.getWorld() != null && lastTeleportResyncWorld != null
+                && !"null".equals(lastTeleportResyncWorld)
+                && !lastTeleportResyncWorld.equals(loc.getWorld().getName())) {
+            return false;
+        }
+        return distanceToStored(lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ, loc)
+                <= MOVING_TELEPORT_RESYNC_TARGET_DISTANCE;
+    }
+
+    private boolean isWorldBackedPendingTeleportTarget(final Location loc) {
+        // Folia packet safety: only real Bukkit-world locations may be stored as MovingData set backs.
+        return loc != null && loc.getWorld() != null && isNearPendingTeleportTarget(loc);
+    }
+
+    private boolean isStalePacketNearStoredPositionModel(final Location packetLocation,
+                                                        final DataPacketFlying packetData,
+                                                        final double storedX,
+                                                        final double storedY,
+                                                        final double storedZ,
+                                                        final long age) {
+        if (packetLocation == null || packetData == null || !packetData.hasPos) {
+            return false;
+        }
+        final double horizontal = horizontalDistance(storedX, storedZ, packetLocation.getX(), packetLocation.getZ());
+        final double vertical = Math.abs(packetLocation.getY() - storedY);
+        return horizontal <= getStalePacketHorizontalModel(packetData)
+                && vertical <= getStalePacketVerticalModel(packetData, age);
+    }
+
+    private double getStalePacketHorizontalModel(final DataPacketFlying packetData) {
+        final DataPacketFlying previous = getPreviousPositionPacket(packetData);
+        if (previous == null) {
+            return MOVING_STALE_PACKET_HORIZONTAL_BASE;
+        }
+        final double motion = horizontalDistance(previous.getX(), previous.getZ(), packetData.getX(), packetData.getZ());
+        return Math.max(MOVING_STALE_PACKET_HORIZONTAL_BASE,
+                motion * MOVING_STALE_PACKET_MOTION_MULTIPLIER + MOVING_POSITION_MATCH_EPSILON);
+    }
+
+    private double getStalePacketVerticalModel(final DataPacketFlying packetData, final long age) {
+        final double ageTicks = Math.max(1.0D, Math.ceil(Math.max(0L, age) / 50.0D) + 1.0D);
+        final double ageEnvelope = MOVING_STALE_PACKET_VERTICAL_BASE
+                + ageTicks * MOVING_STALE_PACKET_VERTICAL_PER_TICK;
+        final DataPacketFlying previous = getPreviousPositionPacket(packetData);
+        if (previous == null) {
+            return Math.min(MOVING_STALE_PACKET_VERTICAL_MAX, ageEnvelope);
+        }
+        final double motion = Math.abs(packetData.getY() - previous.getY());
+        return Math.min(MOVING_STALE_PACKET_VERTICAL_MAX,
+                Math.max(ageEnvelope, motion * MOVING_STALE_PACKET_MOTION_MULTIPLIER
+                        + MOVING_STALE_PACKET_VERTICAL_BASE));
+    }
+
+    private DataPacketFlying getPreviousPositionPacket(final DataPacketFlying packetData) {
+        if (packetData == null) {
+            return null;
+        }
+        lock.lock();
+        try {
+            boolean foundCurrent = false;
+            for (final DataPacketFlying packet : flyingQueue) {
+                if (packet == null || !packet.hasPos) {
+                    continue;
+                }
+                if (foundCurrent) {
+                    return packet;
+                }
+                if (packet == packetData || packet.getSequence() == packetData.getSequence()) {
+                    foundCurrent = true;
+                }
+            }
+            return null;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public long getMovingTeleportGraceAge(final long now) {
+        return lastMovingTeleportTime <= 0L ? -1L : now - lastMovingTeleportTime;
+    }
+
+    public long getOutgoingPositionGraceAge(final long now) {
+        return lastOutgoingPositionTime <= 0L ? -1L : now - lastOutgoingPositionTime;
+    }
+
+    public long getServerPositionJumpGraceAge(final long now) {
+        return lastServerPositionJumpTime <= 0L ? -1L : now - lastServerPositionJumpTime;
+    }
+
+    public long getTeleportCommandGraceAge(final long now) {
+        return lastTeleportCommandTime <= 0L ? -1L : now - lastTeleportCommandTime;
+    }
+
+    public String describeMovingTeleportState(final long now, final Location knownLocation,
+                                              final Location packetLocation,
+                                              final DataPacketFlying packetData) {
+        return new StringBuilder(500)
+                .append("eventAge=").append(getMovingTeleportGraceAge(now))
+                .append(",eventWithinGrace=").append(isWithinMovingTeleportGrace(now))
+                .append(",eventCause=").append(lastMovingTeleportCause)
+                .append(",eventLoc=").append(formatTeleportEventLocation())
+                .append(",eventToKnown=").append(NetDiagnostics.formatStoredDistance(lastMovingTeleportTime, lastMovingTeleportX, lastMovingTeleportY, lastMovingTeleportZ, knownLocation))
+                .append(",eventToPacket=").append(NetDiagnostics.formatStoredDistance(lastMovingTeleportTime, lastMovingTeleportX, lastMovingTeleportY, lastMovingTeleportZ, packetLocation))
+                .append(",outgoingAge=").append(getOutgoingPositionGraceAge(now))
+                .append(",outgoingWithinGrace=").append(isWithinOutgoingPositionGrace(now, knownLocation))
+                .append(",outgoingTracked=").append(lastOutgoingPositionTracked)
+                .append(",outgoingTeleportId=").append(lastOutgoingPositionTeleportId)
+                .append(",outgoingLoc=").append(formatOutgoingPositionLocation())
+                .append(",outgoingToKnown=").append(NetDiagnostics.formatStoredDistance(lastOutgoingPositionTime, lastOutgoingPositionX, lastOutgoingPositionY, lastOutgoingPositionZ, knownLocation))
+                .append(",outgoingToPacket=").append(NetDiagnostics.formatStoredDistance(lastOutgoingPositionTime, lastOutgoingPositionX, lastOutgoingPositionY, lastOutgoingPositionZ, packetLocation))
+                .append(",serverJumpAge=").append(getServerPositionJumpGraceAge(now))
+                .append(",serverJumpWithinGrace=").append(isWithinServerPositionJumpGrace(now, knownLocation, packetLocation))
+                .append(",serverJumpStalePacketModel=").append(isWithinServerPositionJumpStalePacketModel(now,
+                        knownLocation, packetLocation, packetData))
+                .append(",serverJumpFrom=").append(formatServerJumpFrom())
+                .append(",serverJumpTo=").append(formatServerJumpTo())
+                .append(",serverJumpToKnown=").append(NetDiagnostics.formatStoredDistance(lastServerPositionJumpTime, lastServerPositionJumpToX, lastServerPositionJumpToY, lastServerPositionJumpToZ, knownLocation))
+                .append(",serverJumpFromPacket=").append(NetDiagnostics.formatStoredDistance(lastServerPositionJumpTime, lastServerPositionJumpFromX, lastServerPositionJumpFromY, lastServerPositionJumpFromZ, packetLocation))
+                .append(",commandAge=").append(getTeleportCommandGraceAge(now))
+                .append(",commandWithinGrace=").append(isWithinTeleportCommandGrace(now, knownLocation, packetLocation))
+                .append(",commandStalePacketModel=").append(isWithinTeleportCommandStalePacketModel(now,
+                        knownLocation, packetLocation, packetData))
+                .append(",command=").append(lastTeleportCommand)
+                .append(",commandLoc=").append(formatTeleportCommandLocation())
+                .append(",commandToKnown=").append(NetDiagnostics.formatStoredDistance(lastTeleportCommandTime, lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ, knownLocation))
+                .append(",commandToPacket=").append(NetDiagnostics.formatStoredDistance(lastTeleportCommandTime, lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ, packetLocation))
+                .append(",resync=").append(describeTeleportResyncState(now, knownLocation))
+                .append(",queue=").append(teleportQueue.getDebugState(now))
+                .toString();
+    }
+
+    public String describeKeepAliveState(final long now) {
+        return NetDiagnostics.formatKeepAliveState(this, now);
+    }
+
+    private static final class KeepAliveRequest {
+        private final long time;
+        private final long id;
+
+        private KeepAliveRequest(final long time, final long id) {
+            this.time = time;
+            this.id = id;
+        }
+    }
+
+    private void resetMovingTeleportDiagnostics() {
+        lastMovingTeleportTime = 0L;
+        lastMovingTeleportWorld = null;
+        lastMovingTeleportCause = "none";
+        lastOutgoingPositionTime = 0L;
+        lastOutgoingPositionTracked = false;
+        lastOutgoingPositionTeleportId = Integer.MIN_VALUE;
+        lastMovingKnownLocationTime = 0L;
+        lastMovingKnownLocationWorld = null;
+        lastServerPositionJumpTime = 0L;
+        lastServerPositionJumpFromWorld = null;
+        lastServerPositionJumpToWorld = null;
+        lastServerPositionJumpRecoveryUsedTime = 0L;
+        lastTeleportCommandTime = 0L;
+        lastTeleportCommand = "none";
+        lastTeleportCommandWorld = null;
+        lastTeleportResyncMovingDataKey = 0L;
+        lastTeleportResyncRequestTime = 0L;
+        lastTeleportResyncAppliedKey = 0L;
+        lastTeleportResyncReason = "none";
+        lastTeleportResyncWorld = null;
+        lastTeleportResyncDroppedPacketLogTime = 0L;
+        lastTeleportResyncDroppedPacketCount = 0;
+        lastTeleportResyncPendingDropLogCount = 0;
+    }
+
+    private String describeTeleportResyncState(final long now, final Location knownLocation) {
+        return NetDiagnostics.formatTeleportResyncState(lastTeleportResyncMovingDataKey,
+                lastTeleportResyncRequestTime, lastTeleportResyncAppliedKey, lastTeleportResyncReason,
+                lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                lastTeleportResyncYaw, lastTeleportResyncPitch,
+                lastTeleportResyncDroppedPacketCount, knownLocation, now);
+    }
+
+    private void logTeleportResyncStalePacketDrop(final Player player, final long now,
+                                                  final Location knownLocation,
+                                                  final Location packetLocation,
+                                                  final DataPacketFlying packetData,
+                                                  final String reason,
+                                                  final String action,
+                                                  final int queueSizeBeforeClear,
+                                                  final boolean forceLog) {
+        lastTeleportResyncDroppedPacketCount++;
+        lastTeleportResyncPendingDropLogCount++;
+        if (player == null || !CheckUtils.shouldLogDebugToConsole()) {
+            return;
+        }
+        // Teleport model diagnostic: Folia/ProtocolLib can deliver a short pair of old-location packets after teleport.
+        if (lastTeleportResyncDroppedPacketCount <= MOVING_TELEPORT_RESYNC_NORMAL_STALE_PACKET_LIMIT) {
+            return;
+        }
+        if (!forceLog && lastTeleportResyncDroppedPacketLogTime > 0L
+                && now - lastTeleportResyncDroppedPacketLogTime < 10000L) {
+            return;
+        }
+        final int loggedCount = lastTeleportResyncPendingDropLogCount;
+        lastTeleportResyncPendingDropLogCount = 0;
+        lastTeleportResyncDroppedPacketLogTime = now;
+        player.getServer().getLogger().info(NetDiagnostics.formatTeleportStaleDrop(player.getName(),
+                action, reason, lastTeleportResyncDroppedPacketCount, loggedCount, queueSizeBeforeClear,
+                lastTeleportResyncX, lastTeleportResyncY, lastTeleportResyncZ,
+                lastTeleportResyncYaw, lastTeleportResyncPitch, lastTeleportResyncRequestTime,
+                knownLocation, lastServerPositionJumpTime, lastServerPositionJumpFromX,
+                lastServerPositionJumpFromY, lastServerPositionJumpFromZ, lastTeleportCommandTime,
+                lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ,
+                packetLocation, packetData, now));
+    }
+
+    private boolean shouldLogTeleportResyncSuccessToConsole() {
+        return CheckUtils.shouldLogDebugToConsole()
+                && lastTeleportResyncDroppedPacketCount > MOVING_TELEPORT_RESYNC_NORMAL_STALE_PACKET_LIMIT;
+    }
+
+    private int getFlyingQueueSize() {
+        lock.lock();
+        try {
+            return flyingQueue.size();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean matchesPosition(final double x, final double y, final double z, final Location loc) {
+        return loc != null
+            && Math.abs(x - loc.getX()) <= MOVING_POSITION_MATCH_EPSILON
+            && Math.abs(y - loc.getY()) <= MOVING_POSITION_MATCH_EPSILON
+            && Math.abs(z - loc.getZ()) <= MOVING_POSITION_MATCH_EPSILON;
+    }
+
+    private String formatTeleportEventLocation() {
+        return lastMovingTeleportTime <= 0L ? "none"
+                : new StringBuilder(100).append(lastMovingTeleportWorld).append('@')
+                        .append(NetDiagnostics.formatStoredLocation(lastMovingTeleportX, lastMovingTeleportY, lastMovingTeleportZ, lastMovingTeleportYaw, lastMovingTeleportPitch))
+                        .toString();
+    }
+
+    private String formatOutgoingPositionLocation() {
+        return lastOutgoingPositionTime <= 0L ? "none"
+                : NetDiagnostics.formatStoredLocation(lastOutgoingPositionX, lastOutgoingPositionY, lastOutgoingPositionZ, lastOutgoingPositionYaw, lastOutgoingPositionPitch);
+    }
+
+    private String formatServerJumpFrom() {
+        return lastServerPositionJumpTime <= 0L ? "none"
+                : new StringBuilder(100).append(lastServerPositionJumpFromWorld).append('@')
+                        .append(NetDiagnostics.formatStoredLocation(lastServerPositionJumpFromX, lastServerPositionJumpFromY, lastServerPositionJumpFromZ,
+                                lastServerPositionJumpFromYaw, lastServerPositionJumpFromPitch))
+                        .toString();
+    }
+
+    private String formatServerJumpTo() {
+        return lastServerPositionJumpTime <= 0L ? "none"
+                : new StringBuilder(100).append(lastServerPositionJumpToWorld).append('@')
+                        .append(NetDiagnostics.formatStoredLocation(lastServerPositionJumpToX, lastServerPositionJumpToY, lastServerPositionJumpToZ,
+                                lastServerPositionJumpToYaw, lastServerPositionJumpToPitch))
+                        .toString();
+    }
+
+    private String formatTeleportCommandLocation() {
+        return lastTeleportCommandTime <= 0L ? "none"
+                : new StringBuilder(100).append(lastTeleportCommandWorld).append('@')
+                        .append(NetDiagnostics.formatStoredLocation(lastTeleportCommandX, lastTeleportCommandY, lastTeleportCommandZ,
+                                lastTeleportCommandYaw, lastTeleportCommandPitch))
+                        .toString();
+    }
+
+    private double distanceToStored(final double x, final double y, final double z, final Location loc) {
+        return loc == null ? Double.MAX_VALUE : distance(x, y, z, loc.getX(), loc.getY(), loc.getZ());
+    }
+
+    private double horizontalDistance(final double x1, final double z1, final double x2, final double z2) {
+        final double xDiff = x2 - x1;
+        final double zDiff = z2 - z1;
+        return Math.sqrt(xDiff * xDiff + zDiff * zDiff);
+    }
+
+    private double distance(final double x1, final double y1, final double z1,
+                            final double x2, final double y2, final double z2) {
+        final double xDiff = x2 - x1;
+        final double yDiff = y2 - y1;
+        final double zDiff = z2 - z1;
+        return Math.sqrt(xDiff * xDiff + yDiff * yDiff + zDiff * zDiff);
     }
     
     /**
@@ -146,6 +976,7 @@ public class NetData extends ACheckData {
         final Location knownLocation = player.getLocation();
         final MovingData mData = pData.getGenericInstance(MovingData.class);
         Object task = null;
+        // Folia compatibility: packet-level set backs must run on the player's owning region.
         task = SchedulerHelper.runSyncTaskForEntity(player, plugin, (arg) -> {
             /** Get the first set-back location that might be available */
             final Location newTo = mData.hasSetBack() ? mData.getSetBack(knownLocation) :

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetDiagnostics.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetDiagnostics.java
@@ -1,0 +1,178 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.checks.net;
+
+import org.bukkit.Location;
+
+import fr.neatmonster.nocheatplus.checks.net.model.DataPacketFlying;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
+
+/**
+ * Console-only formatting for net packet diagnostics.
+ */
+final class NetDiagnostics {
+
+    private NetDiagnostics() {}
+
+    static String formatKeepAliveState(final NetData data, final long now) {
+        final DataPacketFlying latest = data.getCurrentFlyingPacket();
+        return new StringBuilder(500)
+                .append("packetTime=").append(data.keepAlivePacketTime)
+                .append(",packetAge=").append(data.keepAlivePacketTime <= 0L ? -1L : now - data.keepAlivePacketTime)
+                .append(",previousPacketAge=").append(data.keepAlivePreviousPacketTime <= 0L ? -1L : now - data.keepAlivePreviousPacketTime)
+                .append(",delta=").append(data.keepAlivePacketDelta)
+                .append(",idAvailable=").append(data.keepAlivePacketIdAvailable)
+                .append(",idType=").append(data.keepAlivePacketIdType)
+                .append(",id=").append(data.keepAlivePacketIdAvailable ? Long.toString(data.keepAlivePacketId) : "none")
+                .append(",previousId=").append(data.keepAlivePreviousPacketIdAvailable ? Long.toString(data.keepAlivePreviousPacketId) : "none")
+                .append(",duplicateId=").append(data.keepAliveDuplicateId)
+                .append(",expectedResponse=").append(data.keepAliveExpectedResponse)
+                .append(",expectedAge=").append(data.keepAliveExpectedResponseAge)
+                .append(",outgoingSeen=").append(data.keepAliveOutgoingSeen)
+                .append(",outgoingAge=").append(data.keepAliveOutgoingPacketTime <= 0L ? -1L : now - data.keepAliveOutgoingPacketTime)
+                .append(",outgoingId=").append(data.keepAliveOutgoingPacketIdAvailable ? Long.toString(data.keepAliveOutgoingPacketId) : "none")
+                .append(",pendingOutgoing=").append(data.keepAlivePendingRequests)
+                .append(",fieldCounts=long:").append(data.keepAlivePacketLongCount).append("/int:").append(data.keepAlivePacketIntCount)
+                .append(",outgoingFieldCounts=long:").append(data.keepAliveOutgoingPacketLongCount).append("/int:").append(data.keepAliveOutgoingPacketIntCount)
+                .append(",async=").append(data.keepAlivePacketAsync)
+                .append(",thread=").append(data.keepAlivePacketThread)
+                .append(",outgoingAsync=").append(data.keepAliveOutgoingPacketAsync)
+                .append(",outgoingThread=").append(data.keepAliveOutgoingPacketThread)
+                .append(",lastSharedKeepAliveAge=").append(data.lastKeepAliveTime <= 0L ? -1L : now - data.lastKeepAliveTime)
+                .append(",teleportAges=event:").append(data.getMovingTeleportGraceAge(now))
+                .append(",outgoing:").append(data.getOutgoingPositionGraceAge(now))
+                .append(",serverJump:").append(data.getServerPositionJumpGraceAge(now))
+                .append(",command:").append(data.getTeleportCommandGraceAge(now))
+                .append(",latestFlying=").append(formatLatestFlying(latest, now))
+                .append(",matchedMoveSeq=").append(data.getLastMatchedMoveToSequence())
+                .append(",teleportQueue=").append(data.teleportQueue.getDebugState(now))
+                .toString();
+    }
+
+    static String formatTeleportResyncState(final long movingDataKey, final long requestTime,
+                                            final long appliedKey, final String reason,
+                                            final double x, final double y, final double z,
+                                            final float yaw, final float pitch,
+                                            final int droppedPackets, final Location knownLocation,
+                                            final long now) {
+        if (movingDataKey <= 0L) {
+            return "none";
+        }
+        return new StringBuilder(150)
+                .append("{key=").append(movingDataKey)
+                .append(",age=").append(requestTime <= 0L ? -1L : now - requestTime)
+                .append(",applied=").append(appliedKey == movingDataKey)
+                .append(",reason=").append(reason)
+                .append(",target=").append(formatStoredLocation(x, y, z, yaw, pitch))
+                .append(",targetToKnown=").append(formatStoredDistance(requestTime, x, y, z, knownLocation))
+                .append(",droppedPackets=").append(droppedPackets)
+                .append('}')
+                .toString();
+    }
+
+    static String formatTeleportResyncApplied(final String playerName, final String action, final String reason,
+                                              final double x, final double y, final double z,
+                                              final float yaw, final float pitch) {
+        return new StringBuilder(160)
+                .append("[NCP][NetMoving][resync] player=").append(playerName)
+                .append(" action=").append(action)
+                .append(" reason=").append(reason == null ? "unknown" : reason)
+                .append(" target=").append(formatStoredLocation(x, y, z, yaw, pitch))
+                .toString();
+    }
+
+    static String formatTeleportStaleDrop(final String playerName, final String action, final String reason,
+                                          final int droppedPackets, final int loggedCount,
+                                          final int queueSizeBeforeClear,
+                                          final double targetX, final double targetY, final double targetZ,
+                                          final float targetYaw, final float targetPitch,
+                                          final long targetTime, final Location knownLocation,
+                                          final long serverJumpTime, final double serverJumpFromX,
+                                          final double serverJumpFromY, final double serverJumpFromZ,
+                                          final long commandTime, final double commandX,
+                                          final double commandY, final double commandZ,
+                                          final Location packetLocation, final DataPacketFlying packetData,
+                                          final long now) {
+        return new StringBuilder(420)
+                .append("[NCP][NetMoving][stale-drop] player=").append(playerName)
+                .append(" action=").append(action)
+                .append(" reason=").append(reason == null ? "unknown" : reason)
+                .append(" droppedPackets=").append(droppedPackets)
+                .append(" loggedCount=").append(loggedCount)
+                .append(" queueSizeBeforeClear=").append(queueSizeBeforeClear)
+                .append(" target=").append(formatStoredLocation(targetX, targetY, targetZ, targetYaw, targetPitch))
+                .append(" targetToKnown=").append(formatStoredDistance(targetTime, targetX, targetY, targetZ, knownLocation))
+                .append(" packetToServerJumpFrom=").append(formatStoredDistance(serverJumpTime,
+                        serverJumpFromX, serverJumpFromY, serverJumpFromZ, packetLocation))
+                .append(" packetToCommand=").append(formatStoredDistance(commandTime, commandX, commandY, commandZ, packetLocation))
+                .append(" packet=").append(formatPacket(packetData, now))
+                .toString();
+    }
+
+    static String formatStoredLocation(final double x, final double y, final double z, final float yaw, final float pitch) {
+        return new StringBuilder(90)
+                .append("x=").append(StringUtil.fdec3.format(x))
+                .append(",y=").append(StringUtil.fdec3.format(y))
+                .append(",z=").append(StringUtil.fdec3.format(z))
+                .append(",yaw=").append(StringUtil.fdec3.format(yaw))
+                .append(",pitch=").append(StringUtil.fdec3.format(pitch))
+                .toString();
+    }
+
+    static String formatStoredDistance(final long storedTime, final double x, final double y, final double z, final Location loc) {
+        if (storedTime <= 0L || loc == null) {
+            return "none";
+        }
+        final double xDiff = loc.getX() - x;
+        final double yDiff = loc.getY() - y;
+        final double zDiff = loc.getZ() - z;
+        return new StringBuilder(80)
+                .append("h=").append(StringUtil.fdec3.format(Math.sqrt(xDiff * xDiff + zDiff * zDiff)))
+                .append("/y=").append(StringUtil.fdec3.format(Math.abs(yDiff)))
+                .append("/total=").append(StringUtil.fdec3.format(Math.sqrt(xDiff * xDiff + yDiff * yDiff + zDiff * zDiff)))
+                .toString();
+    }
+
+    static String formatPacket(final DataPacketFlying packetData, final long now) {
+        if (packetData == null) {
+            return "none";
+        }
+        return new StringBuilder(120)
+                .append("seq=").append(packetData.getSequence())
+                .append(",age=").append(now - packetData.time)
+                .append(",type=").append(packetData.getSimplifiedContentType())
+                .append(",tracked=").append(packetData.isTracked())
+                .append(",ground=").append(packetData.onGround)
+                .append(",hCollision=").append(packetData.horizontalCollision)
+                .append(",hasPos=").append(packetData.hasPos)
+                .toString();
+    }
+
+    private static String formatLatestFlying(final DataPacketFlying latest, final long now) {
+        if (latest == null) {
+            return "none";
+        }
+        return new StringBuilder(160)
+                .append("seq=").append(latest.getSequence())
+                .append(",age=").append(now - latest.time)
+                .append(",tracked=").append(latest.isTracked())
+                .append(",type=").append(latest.getSimplifiedContentType())
+                .append(",ground=").append(latest.onGround)
+                .append(",hcollide=").append(latest.horizontalCollision)
+                .append(",hasPos=").append(latest.hasPos)
+                .append(",hasLook=").append(latest.hasLook)
+                .toString();
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/model/TeleportQueue.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/model/TeleportQueue.java
@@ -103,6 +103,34 @@ public class TeleportQueue {
     }
 
     /**
+     * Compact diagnostic snapshot for NET_MOVING false-positive analysis.
+     */
+    public String getDebugState(final long now) {
+        final StringBuilder builder = new StringBuilder(300);
+        lock.lock();
+        builder.append("expectOutgoing=").append(expectOutgoing == null ? "none" : expectOutgoing.toString());
+        builder.append(",expectIncomingSize=").append(expectIncoming.size());
+        if (!expectIncoming.isEmpty()) {
+            builder.append(",incomingFirst=").append(formatCountable(expectIncoming.getFirst(), now));
+            builder.append(",incomingLast=").append(formatCountable(expectIncoming.getLast(), now));
+        }
+        builder.append(",lastAck=").append(lastAck == null ? "none" : formatCountable(lastAck, now));
+        builder.append(",ackRef=lastOutgoing:").append(lastAckReference.lastOutgoingId)
+                .append("/maxConfirmed:").append(lastAckReference.maxConfirmedId);
+        builder.append(",maxAge=").append(maxAge);
+        lock.unlock();
+        return builder.toString();
+    }
+
+    private String formatCountable(final CountableLocation ref, final long now) {
+        final StringBuilder builder = new StringBuilder(160);
+        builder.append(ref.toString());
+        builder.append(",age=");
+        builder.append(now >= ref.time ? now - ref.time : -(ref.time - now));
+        return builder.toString();
+    }
+
+    /**
      * Call for Bukkit events (expect this packet to be sent).<br>
      * TODO: The method name is misleading, as this also should be called with
      * expected outgoing packet.
@@ -243,6 +271,23 @@ public class TeleportQueue {
         }
         lock.unlock();
         return ackState;
+    }
+
+    /**
+     * Accept a movement packet that matches the teleport location from a Bukkit
+     * event before ProtocolLib has observed the matching outgoing position.
+     */
+    public boolean consumeExpectedOutgoingPosition(final DataPacketFlying packetData) {
+        if (packetData == null || !packetData.hasPos) {
+            return false;
+        }
+        lock.lock();
+        final boolean match = expectOutgoing != null && expectOutgoing.isSamePos(packetData);
+        if (match) {
+            expectOutgoing = null;
+        }
+        lock.unlock();
+        return match;
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/SchedulerHelper.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/SchedulerHelper.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
+import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.plugin.Plugin;
@@ -31,6 +32,7 @@ import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 /**
  * Utility class to provide compatibility with Paper's regionized, multi-threaded server implementation (a.k.a.: Folia), using reflection.
  * If the server is not running Folia, use Bukkit's scheduler.
+ * Keep Folia-specific calls here so the rest of NCP can stay source-compatible with regular Bukkit/Paper APIs.
  */
 public class SchedulerHelper {
 
@@ -39,12 +41,118 @@ public class SchedulerHelper {
     private static final Class<?> GlobalRegionScheduler = ReflectionUtil.getClass("io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler");
     private static final Class<?> EntityScheduler = ReflectionUtil.getClass("io.papermc.paper.threadedregions.scheduler.EntityScheduler");
     private static final boolean isFoliaServer = RegionizedServer && GlobalRegionScheduler != null && EntityScheduler != null; // && AsyncScheduler != null
+    private static final Method Bukkit_isOwnedByCurrentRegionLocation = ReflectionUtil.getMethod(Bukkit.class, "isOwnedByCurrentRegion", Location.class);
+    private static final Method Bukkit_isOwnedByCurrentRegionLocationRadius = ReflectionUtil.getMethod(Bukkit.class, "isOwnedByCurrentRegion", Location.class, int.class);
+    private static final Method Bukkit_isOwnedByCurrentRegionWorldChunk = ReflectionUtil.getMethod(Bukkit.class, "isOwnedByCurrentRegion", World.class, int.class, int.class);
+    private static final Method Bukkit_isOwnedByCurrentRegionWorldChunkRadius = ReflectionUtil.getMethod(Bukkit.class, "isOwnedByCurrentRegion", World.class, int.class, int.class, int.class);
+    private static final Method Bukkit_isOwnedByCurrentRegionEntity = ReflectionUtil.getMethod(Bukkit.class, "isOwnedByCurrentRegion", Entity.class);
     
     /**
      * @return Whether the server is running Folia
      */
     public static boolean isFoliaServer() {
         return isFoliaServer;
+    }
+
+    /**
+     * Check whether the current Folia region owns a Bukkit location before
+     * touching world/block state. Non-Folia servers keep the old behavior.
+     *
+     * @param location The block/world location to check.
+     * @return True if the location is safe to access on the current thread.
+     */
+    public static boolean isOwnedByCurrentRegion(final Location location) {
+        return isOwnedByCurrentRegion(location, 0);
+    }
+
+    /**
+     * Check whether the current Folia region owns a location and a square chunk
+     * radius around it. Use this before code that scans neighboring blocks.
+     *
+     * @param location The block/world location to check.
+     * @param squareRadiusChunks Radius in chunks, not squared distance.
+     * @return True if the area is safe to access on the current thread.
+     */
+    public static boolean isOwnedByCurrentRegion(final Location location, final int squareRadiusChunks) {
+        if (!isFoliaServer) {
+            return true;
+        }
+        if (location == null || location.getWorld() == null) {
+            return false;
+        }
+        if (squareRadiusChunks > 0 && Bukkit_isOwnedByCurrentRegionLocationRadius != null) {
+            return invokeOwnershipCheck(Bukkit_isOwnedByCurrentRegionLocationRadius, location, squareRadiusChunks);
+        }
+        if (squareRadiusChunks == 0 && Bukkit_isOwnedByCurrentRegionLocation != null) {
+            return invokeOwnershipCheck(Bukkit_isOwnedByCurrentRegionLocation, location);
+        }
+        return isOwnedByCurrentRegion(location.getWorld(), location.getBlockX(), location.getBlockZ(), squareRadiusChunks);
+    }
+
+    /**
+     * Check whether the current Folia region owns the chunk containing a block.
+     *
+     * @param world The world to check.
+     * @param blockX The block x coordinate.
+     * @param blockZ The block z coordinate.
+     * @return True if the block is safe to access on the current thread.
+     */
+    public static boolean isOwnedByCurrentRegion(final World world, final int blockX, final int blockZ) {
+        return isOwnedByCurrentRegion(world, blockX, blockZ, 0);
+    }
+
+    /**
+     * Check whether the current Folia region owns the chunk containing a block,
+     * plus an optional square chunk radius.
+     *
+     * @param world The world to check.
+     * @param blockX The block x coordinate.
+     * @param blockZ The block z coordinate.
+     * @param squareRadiusChunks Radius in chunks, not squared distance.
+     * @return True if the block area is safe to access on the current thread.
+     */
+    public static boolean isOwnedByCurrentRegion(final World world, final int blockX, final int blockZ, final int squareRadiusChunks) {
+        if (!isFoliaServer) {
+            return true;
+        }
+        if (world == null) {
+            return false;
+        }
+        final int chunkX = blockX >> 4;
+        final int chunkZ = blockZ >> 4;
+        if (squareRadiusChunks > 0 && Bukkit_isOwnedByCurrentRegionWorldChunkRadius != null) {
+            return invokeOwnershipCheck(Bukkit_isOwnedByCurrentRegionWorldChunkRadius, world, chunkX, chunkZ, squareRadiusChunks);
+        }
+        if (Bukkit_isOwnedByCurrentRegionWorldChunk != null) {
+            return invokeOwnershipCheck(Bukkit_isOwnedByCurrentRegionWorldChunk, world, chunkX, chunkZ);
+        }
+        return false;
+    }
+
+    /**
+     * Check whether the current Folia region owns an entity before reading
+     * entity state or nearby entities.
+     *
+     * @param entity The entity to check.
+     * @return True if the entity is safe to access on the current thread.
+     */
+    public static boolean isOwnedByCurrentRegion(final Entity entity) {
+        if (!isFoliaServer) {
+            return true;
+        }
+        if (entity == null || Bukkit_isOwnedByCurrentRegionEntity == null) {
+            return false;
+        }
+        return invokeOwnershipCheck(Bukkit_isOwnedByCurrentRegionEntity, entity);
+    }
+
+    private static boolean invokeOwnershipCheck(final Method method, final Object... arguments) {
+        try {
+            return Boolean.TRUE.equals(method.invoke(null, arguments));
+        }
+        catch (Throwable t) {
+            return false;
+        }
     }
     
     /**
@@ -58,6 +166,7 @@ public class SchedulerHelper {
         if (!isFoliaServer) {
             return Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> run.accept(null)).getTaskId();
         }
+        // Folia async scheduler signatures have moved across builds; these callers already do async-safe work.
         //try {
         //    Method getSchedulerMethod = ReflectionUtil.getMethodNoArgs(Server.class, "getAsyncScheduler", AsyncScheduler);
         //    Object asyncScheduler = getSchedulerMethod.invoke(Bukkit.getServer());
@@ -71,8 +180,7 @@ public class SchedulerHelper {
         //catch (Exception e) {
             // Second attempt, should be happening during onDisable calling from BukkitLogNodeDispatcher
             Thread thread = Executors.defaultThreadFactory().newThread(() -> run.accept(null));
-            if (thread == null) return null;
-            thread.run();
+            thread.start();
             return thread;
         //}
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BridgeHealth.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BridgeHealth.java
@@ -41,7 +41,7 @@ import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
  * @author asofold
  *
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 public class BridgeHealth {
 
     // TODO: Move to (smaller?) IGenericInstanceHandle instances.
@@ -326,7 +326,7 @@ public class BridgeHealth {
         }
     }
 
-    public static EntityDamageEvent getEntityDamageEvent(final Entity entity, 
+    public static EntityDamageEvent getEntityDamageEvent(final Entity entity,
             final DamageCause damageCause, final double damage) {
         try{
             return new EntityDamageEvent(entity, damageCause, damage);
@@ -341,6 +341,10 @@ public class BridgeHealth {
             }
             return null;
         }
+    }
+
+    public static void setLastDamageCause(final Entity entity, final EntityDamageEvent event) {
+        entity.setLastDamageCause(event);
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/DefaultGenericInstanceRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/DefaultGenericInstanceRegistry.java
@@ -242,31 +242,36 @@ public class DefaultGenericInstanceRegistry implements GenericInstanceRegistry, 
     @SuppressWarnings("unchecked")
     private <T> Registration<T> createEmptyRegistration(Class<T> registeredFor) {
         lock.lock();
-        Registration<T> registration = (Registration<T>) registrations.get(registeredFor); // Re-check.
-        if (registration == null) {
-            try {
+        try {
+            Registration<T> registration = (Registration<T>) registrations.get(registeredFor); // Re-check.
+            if (registration == null) {
                 // TODO: Consider individual locks / configuration for it.
                 registration = new Registration<T>(registeredFor, null, this, this, lock);
                 this.registrations.put(registeredFor, registration);
             }
-            catch (Throwable t) {
-                lock.unlock();
-                throw new IllegalArgumentException(t); // Might document.
-            }
+            return registration;
         }
-        lock.unlock();
-        return registration;
+        catch (Throwable t) {
+            throw new IllegalArgumentException(t); // Might document.
+        }
+        finally {
+            lock.unlock();
+        }
     }
 
     @Override
     public <T> void unregisterGenericInstanceRegistryListener(Class<T> registeredFor, IGenericInstanceRegistryListener<T> listener) {
         lock.lock();
-        // (Include getRegistration, as no object creation is involved.)
-        Registration<T> registration = getRegistration(registeredFor, false);
-        if (registration != null) {
-            registration.unregisterListener(listener);
+        try {
+            // (Include getRegistration, as no object creation is involved.)
+            Registration<T> registration = getRegistration(registeredFor, false);
+            if (registration != null) {
+                registration.unregisterListener(listener);
+            }
         }
-        lock.lock();
+        finally {
+            lock.unlock();
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -82,6 +82,9 @@ public abstract class ConfPaths {
     private static final String LOGGING                                  = "logging.";
     public static final String  LOGGING_ACTIVE                           = LOGGING + SUB_ACTIVE;
     public static final String  LOGGING_MAXQUEUESIZE                     = LOGGING + "max-queue-size";
+    private static final String LOGGING_DEBUG_SECTION                    = LOGGING + "debug.";
+    /** Toggle for custom verbose diagnostic lines such as [NCP][SurvivalFly][detail]. */
+    public static final String  LOGGING_DEBUG_TO_CONSOLE                 = LOGGING_DEBUG_SECTION + "to-console";
 
     private static final String LOGGING_BACKEND                          = LOGGING + "backend.";
     private static final String LOGGING_BACKEND_CONSOLE                  = LOGGING_BACKEND + "console.";
@@ -629,6 +632,8 @@ public abstract class ConfPaths {
     private static final String MOVING_SURVIVALFLY_EXTENDED                 = MOVING_SURVIVALFLY + "extended.";
     public static final String MOVING_SURVIVALFLY_EXTENDED_RESETITEM        = MOVING_SURVIVALFLY_EXTENDED + "reset-activeitem";
     public static final String MOVING_SURVIVALFLY_EXTENDED_STRICT_HORIZONTAL_PREDICTION = MOVING_SURVIVALFLY_EXTENDED + "strict-speed-prediction";
+    private static final String MOVING_SURVIVALFLY_ELYTRA                   = MOVING_SURVIVALFLY + "elytra.";
+    public static final String MOVING_SURVIVALFLY_ELYTRA_ENFORCE            = MOVING_SURVIVALFLY_ELYTRA + "enforce";
     private static final String MOVING_SURVIVALFLY_LENIENCY                 = MOVING_SURVIVALFLY + "leniency.";
     public static final String MOVING_SURVIVALFLY_LENIENCY_FREEZECOUNT      = MOVING_SURVIVALFLY_LENIENCY + "freeze-count";
     public static final String MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR      = MOVING_SURVIVALFLY_LENIENCY + "freeze-inair";
@@ -646,6 +651,7 @@ public abstract class ConfPaths {
     @GlobalConfig
     public static final String  MOVING_SURVIVALFLY_HOVER                    = MOVING_SURVIVALFLY + "hover.";
     public static final String  MOVING_SURVIVALFLY_HOVER_CHECK              = MOVING_SURVIVALFLY_HOVER + SUB_ACTIVE;
+    public static final String  MOVING_SURVIVALFLY_HOVER_ELYTRA_ENFORCE     = MOVING_SURVIVALFLY_HOVER + "elytra-enforce";
     public static final String  MOVING_SURVIVALFLY_HOVER_STEP               = MOVING_SURVIVALFLY_HOVER + "step";
     public static final String  MOVING_SURVIVALFLY_HOVER_TICKS              = MOVING_SURVIVALFLY_HOVER + "ticks";
     public static final String  MOVING_SURVIVALFLY_HOVER_LOGINTICKS         = MOVING_SURVIVALFLY_HOVER + "login-ticks";

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -50,13 +50,16 @@ public class DefaultConfig extends ConfigFile {
         //        not set(ConfPaths.CONFIGVERSION_SAVED, -1);
         set(ConfPaths.LOGGING_ACTIVE, true, 154);
         set(ConfPaths.LOGGING_MAXQUEUESIZE, 5000, 154);
+        // Compatibility diagnostics are opt-in because the extra movement/Folia details are too noisy for normal servers.
+        set(ConfPaths.LOGGING_DEBUG_TO_CONSOLE, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_STATUS, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_COMMANDS_ACTIONS, false, 1090);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_DEBUG, true, 154);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_DEBUGONLY, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_TRACE, false, 154);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_NOTIFY, false, 154);
-        set(ConfPaths.LOGGING_BACKEND_CONSOLE_ACTIVE, true, 154);
+        // Default console backend off: server owners can opt in to console logging when debugging false positives.
+        set(ConfPaths.LOGGING_BACKEND_CONSOLE_ACTIVE, false, 154);
         set(ConfPaths.LOGGING_BACKEND_CONSOLE_ASYNCHRONOUS, true, 154);
         set(ConfPaths.LOGGING_BACKEND_FILE_ACTIVE, true, 154);
         set(ConfPaths.LOGGING_BACKEND_FILE_PREFIX, "", 154);
@@ -121,7 +124,8 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.BLOCKBREAK_FASTBREAK_STRICT, true, 154);
         set(ConfPaths.BLOCKBREAK_FASTBREAK_DELAY, 10, 154); 
         set(ConfPaths.BLOCKBREAK_FASTBREAK_MOD_SURVIVAL, 100, 154);
-        set(ConfPaths.BLOCKBREAK_FASTBREAK_GRACE, 500, 154);
+        // False-positive tuning: modern/Folia block-dig timing can need a larger grace, but keep it configurable.
+        set(ConfPaths.BLOCKBREAK_FASTBREAK_GRACE, 2000, 154);
         set(ConfPaths.BLOCKBREAK_FASTBREAK_ACTIONS, "cancel vl>5 cancel log:fastbreak:4:2:i vl>50 cancel log:fastbreak:0:2:if cmdc:kickfastbreak:2:5", 154);
         // Frequency
         set(ConfPaths.BLOCKBREAK_FREQUENCY_CHECK, "default", 154);
@@ -479,6 +483,8 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_SURVIVALFLY_STEPHEIGHT, "default", 154);
         set(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_RESETITEM, true, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_STRICT_HORIZONTAL_PREDICTION, true, 154);
+        // Elytra model collection: keep false while tuning from flightTrace/detail logs to avoid setback deaths.
+        set(ConfPaths.MOVING_SURVIVALFLY_ELYTRA_ENFORCE, false, 154);
         // SurvivalFly - ViolationFrequencyHook
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_ACTIVE, true, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_VLFREQUENCY_DEBUG, false, 154);
@@ -496,6 +502,8 @@ public class DefaultConfig extends ConfigFile {
             + " vl>2100 cancel log:survivalflyhighvl:0:4:icf cmdc:kickfly:0:15", 154);     
         // SurvivalFly - Hover Subcheck
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_CHECK, true, 154); // Not a check type yet.
+        // Elytra hover model telemetry stays data-only by default until server owners opt into enforcement.
+        set(ConfPaths.MOVING_SURVIVALFLY_HOVER_ELYTRA_ENFORCE, false, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_STEP, 5, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_TICKS, 85, 154);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_LOGINTICKS, 60, 154);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/Permissions.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/Permissions.java
@@ -58,6 +58,7 @@ public class Permissions {
 
     // Notifications (in-game).
     public static final RegisteredPermission  NOTIFY                       = add(NOCHEATPLUS + ".notify");
+    public static final RegisteredPermission  COMPAT_BEDROCK              = add(NOCHEATPLUS + ".compat.bedrock");
 
     // Command permissions.
     public static final RegisteredPermission  COMMAND                      = add(NOCHEATPLUS + ".command");

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/CheckUtils.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/CheckUtils.java
@@ -28,6 +28,8 @@ import fr.neatmonster.nocheatplus.checks.fight.FightData;
 import fr.neatmonster.nocheatplus.checks.inventory.InventoryData;
 import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
 import fr.neatmonster.nocheatplus.components.concurrent.IPrimaryThreadContextTester;
+import fr.neatmonster.nocheatplus.config.ConfigManager;
+import fr.neatmonster.nocheatplus.config.ConfPaths;
 import fr.neatmonster.nocheatplus.logging.StaticLog;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
@@ -76,6 +78,11 @@ public class CheckUtils {
             improperAsynchronousAPIAccess(checkType);
             return false;
         }
+    }
+
+    public static boolean shouldLogDebugToConsole() {
+        // This gates the extra diagnostic console spam added for compatibility tuning, not the normal NCP backend loggers.
+        return ConfigManager.getConfigFile().getBoolean(ConfPaths.LOGGING_DEBUG_TO_CONSOLE, false);
     }
 
     /**

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -1309,6 +1309,10 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
     private void onJoinLow(final Player player) {
         final String playerName = player.getName();
         final IPlayerData data = DataManager.getPlayerData(player);
+        data.setBedrockPlayer(isBedrockPlayer(player, data));
+        if (data.isBedrockPlayer()) {
+            logManager.info(Streams.STATUS, "Detected Bedrock player: " + playerName);
+        }
         if (data.hasPermission(Permissions.NOTIFY, player)) { // Updates the cache.
             // Login notifications...
             //            // Update available.
@@ -1334,6 +1338,32 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
                 logManager.severe(Streams.INIT, t);
             }
         }
+    }
+
+    private boolean isBedrockPlayer(final Player player, final IPlayerData data) {
+        if (data.hasPermission(Permissions.COMPAT_BEDROCK, player)) {
+            return true;
+        }
+        try {
+            final Class<?> apiClass = Class.forName("org.geysermc.floodgate.api.FloodgateApi");
+            final Object api = apiClass.getMethod("getInstance").invoke(null);
+            return Boolean.TRUE.equals(apiClass.getMethod("isFloodgatePlayer", java.util.UUID.class).invoke(api, player.getUniqueId()));
+        }
+        catch (Throwable ignored) {}
+        try {
+            final Class<?> apiClass = Class.forName("org.geysermc.geyser.api.GeyserApi");
+            final Object api = apiClass.getMethod("api").invoke(null);
+            if (api != null) {
+                try {
+                    return Boolean.TRUE.equals(apiClass.getMethod("isBedrockPlayer", java.util.UUID.class).invoke(api, player.getUniqueId()));
+                }
+                catch (NoSuchMethodException ignored) {
+                    return apiClass.getMethod("connectionByUuid", java.util.UUID.class).invoke(api, player.getUniqueId()) != null;
+                }
+            }
+        }
+        catch (Throwable ignored) {}
+        return player.getName().startsWith(".");
     }
 
     private void onLeave(final Player player) {

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Links
 ###### Support and Documentation
 * [Issues/Tickets](https://github.com/Updated-NoCheatPlus/NoCheatPlus/issues)
 * [Wiki](https://github.com/Updated-NoCheatPlus/Docs)
+* [Compatibility debugging guide](docs/compat-debugging.md)
 * [Configuration](https://github.com/Updated-NoCheatPlus/Docs#configuration)
 * [Permissions](https://github.com/Updated-NoCheatPlus/Docs/blob/master/Settings/Permissions.md)
 * [Commands](https://github.com/Updated-NoCheatPlus/Docs/blob/master/Settings/Commands.md)

--- a/docs/compat-debugging.md
+++ b/docs/compat-debugging.md
@@ -1,0 +1,151 @@
+# Compatibility Debugging Guide
+
+This guide explains the extra compatibility diagnostics added for Bedrock, Folia, modern movement clients, and false-positive tuning. The goal is to make console logs easier to read without losing the detailed values needed to refine checks.
+
+## Enabling Console Detail
+
+The detailed compatibility lines are opt-in because they can be noisy on live servers. Enable them only while testing or collecting false-positive reports.
+
+Relevant config paths:
+
+```yaml
+logging:
+  debug:
+    to-console: true
+  backend:
+    console:
+      active: true
+```
+
+The normal violation/debug settings still control whether a check has enough debug context to print.
+
+## Reading A Detail Line
+
+Most new detail lines keep the same shape:
+
+```text
+[NCP][CheckName][detail] player=name subcheck=SPECIFIC_BRANCH summary=short_reason{...} ... tags=...
+```
+
+Important fields:
+
+| Field | Meaning |
+| --- | --- |
+| `subcheck` | The concrete branch behind the umbrella check name. Use this first when sorting logs. |
+| `summary` | Short human-readable diagnosis for quick scanning. This is intentionally near the front of the line. |
+| `movementMode` | SurvivalFly movement state such as `GROUND`, `WATER`, `CLIMBABLE`, `ELYTRA_GLIDING`, or `ELYTRA_FIREWORK`. |
+| `model` | The selected SurvivalFly model branch, if one matched the movement context. |
+| `hOver` | Remaining horizontal distance over the model boundary after model handling. |
+| `yOver` | Remaining vertical distance over the model boundary after model handling. |
+| `physicsModel` | Diagnostic-only gravity/velocity probe for SurvivalFly. It shows expected next fall speed, actual acceleration, server velocity differences, and horizontal-vs-vertical glide ratios. |
+| `tags` | Full diagnostic markers for deeper analysis. |
+
+## SurvivalFly Tags
+
+SurvivalFly logs are the densest because one umbrella check covers many movement states.
+
+Common tag groups:
+
+| Tag prefix | Meaning |
+| --- | --- |
+| `subcheck_` | Final readable failure type, for example `subcheck_elytra_firework_y`. |
+| `mode_` | Broad movement mode at the time of the violation. |
+| `branch_` | Important branch/context that influenced diagnosis, such as liquid, collision, velocity, or recent setback. |
+| `branch_model_` | The code selected a named movement model for this move. |
+| `model_*` | A selected model accepted part of the movement. Suffix `_h` means horizontal, `_y` means vertical. |
+| `model_*_miss` | A model was selected but did not accept the movement envelope. This is usually the next place to refine. |
+| `diag_*` | Diagnostic probe only. It marks a likely area to inspect but does not mean movement was accepted. |
+
+Example:
+
+```text
+summary=elytra_firework_y{mode=elytra_firework,model=elytra_firework,axis=y,hOver=0,yOver=0.035,tags=subcheck_elytra_firework_y+branch_elytra_state+branch_model_elytra_firework}
+```
+
+Practical reading:
+
+- The player was actively gliding with a firework.
+- The selected model was `elytra_firework`.
+- The remaining miss was vertical (`axis=y`).
+- `yOver=0.035` is the amount still outside the accepted model.
+- If this was false, refine the elytra firework vertical model, not generic SurvivalFly.
+
+## Teleport And Portal Sync
+
+Folia and modern teleport plugins can use `teleportAsync`, portal callbacks, or direct server position packets. In those cases, packet-level `NET_MOVING` may see the position jump before SurvivalFly has clean movement history for the new location.
+
+Useful tags:
+
+| Tag | Meaning |
+| --- | --- |
+| `server_position_jump_stale_packet_model` | `NET_MOVING` matched a stale pre-teleport packet to a recent server-side position jump. This is not elytra-specific. |
+| `teleport_command_stale_packet_model` | A command such as `/home` or `/rtp` was recently issued, and the old packet still fit the command-location stale-packet model. |
+| `server_position_jump_recovery_grace` | One last-resort stale packet was consumed after a server-side jump when movement history was invalid. |
+| `server_position_jump_air_resync_horizontal_model` | SurvivalFly accepted a small post-teleport air/fall horizontal mismatch using the server-position resync model. |
+| `server_position_jump_air_resync_vertical_model` | SurvivalFly accepted the next post-teleport vertical packet as a vanilla gravity continuation. |
+
+The final teleport sync model handles the common Folia/ProtocolLib packet order pattern where one or two old-location packets arrive after a command teleport, `/rtp`, `/spawn`, `/home`, respawn, or portal-style server-position jump. Those packets are deleted from packet history and do not represent player movement at the new location. Console diagnostics are intentionally quiet for that normal one-or-two-packet pattern; repeated stale packets beyond that still log so the packet ordering model can be refined.
+
+If teleport false positives remain, include the `NET_MOVING` detail, the matching `NET_MOVING][teleport]` line, and the next SurvivalFly detail line. The useful fields are `serverJumpAge`, `serverJumpFrom`, `serverJumpTo`, `serverJumpStalePacketModel`, `commandStalePacketModel`, `packetModel`, `movementMode`, `movementModel`, `modelProbe`, `summary`, and `tags`.
+
+## Folia Block Cache Fallback
+
+Folia region ownership can make direct block reads unsafe from packet or async paths. The Bukkit block cache now first checks normal region ownership, then retries with exact-location ownership before returning `AIR` or legacy data `0` as the final safe fallback.
+
+Single fallback events during teleport or chunk handoff are expected and are not printed to console. Repeated fallback events are rate-limited and logged as safe fallback diagnostics with resolved and final-fallback counts.
+
+## Other Check Summaries
+
+The other detailed checks now include short `summary` fields too:
+
+| Check | Summary shape | What it helps identify |
+| --- | --- | --- |
+| FastBreak | `summary=block_timing{...}` | Block/tool timing, missing break time, grace budget. |
+| FightAngle | `summary=angle_*{...}` | Aim angle, timing, movement, or target-switch branch. |
+| FightCritical | `summary=critical_*{...}` | Fall-distance mismatch, reset-condition criticals, jump-phase desync. |
+| BlockDirection | `summary=block_direction{...}` | Ray miss vs unreachable block face. |
+| MorePackets | `summary=packet_rate{...}` | Packet-rate or burst violations separate from movement model errors. |
+| Passable | `summary=passable_raytrace{...}` | Ray-trace branch and block types involved in stuck/inside-block flags. |
+| KeepAliveFrequency | `summary=keepalive_bucket{...}` | Bucket timing, duplicate/fast keep-alive replies, Folia async timing. |
+| NetMoving | `summary=net_moving{...}` | Extreme packet movement vs teleport/server-position stale-packet models. |
+
+## What To Include In A Bug Report
+
+When reporting a false positive, include:
+
+1. The full `[NCP][...][detail]` line, not only the short `[NC+] [VL]` line.
+2. What the player was doing in plain terms, such as "Bedrock player running up stairs" or "elytra firework into ground".
+3. Whether the player was Bedrock or Java.
+4. The block or environment involved, especially stairs, slabs, lanterns, carpet, vines, scaffolding, water, boats, or portals.
+5. A few lines before and after the flag if teleport, respawn, knockback, firework, or combat happened.
+
+For SurvivalFly false positives, the most useful first fields are:
+
+```text
+summary=...
+movementMode=...
+subcheck=...
+movementModel=...
+physicsModel=...
+modelProbe=...
+elytraModel=...
+tags=...
+```
+
+## Model vs Grace
+
+Some constants still contain `GRACE` in their names for history. In the newer model paths, those values should be treated as empirical residual boundaries inside a selected movement state.
+
+Preferred design:
+
+```text
+identify movement state -> select model -> calculate boundary -> compare actual movement
+```
+
+Avoid this design when changing future code:
+
+```text
+normal model fails -> broad grace accepts actual movement afterward
+```
+
+If a tolerance remains because packet ordering, Folia timing, teleport sync, or floating-point precision cannot be modeled exactly, document that reason next to the code.


### PR DESCRIPTION
## Summary

Improves Folia-safe packet, teleport, and keep-alive synchronization handling.

## What Changed

- Adds safer Folia-aware scheduling helpers.
- Updates command/action execution paths to avoid unsafe thread access.
- Improves teleport/RTP/spawn resync handling between net packets and movement state.
- Adds keep-alive packet parsing details for modern packet shapes.
- Adds keep-alive diagnostics for timing, async thread state, packet IDs, and expected responses.
- Adds net movement diagnostics for stale packets, teleport queues, server position jumps, and resync state.
- Improves handling of stale movement packets after teleports so old packets do not drag players back.
- Adds shared movement data resync support used by the net synchronization path.

## Why

Folia and modern packet timing can expose movement, teleport, and keep-alive events on different threads or in slightly different orders than legacy Bukkit assumptions. These changes make the net/movement bridge safer and easier to diagnose without relying on broad movement forgiveness.

## Notes

This is PR 2 in the stacked series.

Base branch: `diagnostics-config-docs`  
Head branch: `folia-net-sync`
